### PR TITLE
feat: add API to delete a connection, and add patch for multi-tenancy OOB connection

### DIFF
--- a/patches/@credo-ts+core+0.5.3+007+outofband-connection-fix.patch
+++ b/patches/@credo-ts+core+0.5.3+007+outofband-connection-fix.patch
@@ -1,0 +1,40 @@
+diff --git a/node_modules/@credo-ts/core/build/modules/oob/OutOfBandApi.js b/node_modules/@credo-ts/core/build/modules/oob/OutOfBandApi.js
+index 141bc8d..e84e210 100644
+--- a/node_modules/@credo-ts/core/build/modules/oob/OutOfBandApi.js
++++ b/node_modules/@credo-ts/core/build/modules/oob/OutOfBandApi.js
+@@ -432,17 +432,30 @@ let OutOfBandApi = class OutOfBandApi {
+                 }
+                 else {
+                     // Wait until the connection is ready and then pass the messages to the agent for further processing
+-                    this.connectionsApi
+-                        .returnWhenIsConnected(connectionRecord.id, { timeoutMs })
+-                        .then((connectionRecord) => this.emitWithConnection(outOfBandRecord, connectionRecord, messages))
+-                        .catch((error) => {
++                    // this.connectionsApi
++                    //     .returnWhenIsConnected(connectionRecord.id, { timeoutMs })
++                    //     .then((connectionRecord) => this.emitWithConnection(outOfBandRecord, connectionRecord, messages))
++                    //     .catch((error) => {
++                    //     if (error instanceof rxjs_1.EmptyError) {
++                    //         this.logger.warn(`Agent unsubscribed before connection got into ${connections_1.DidExchangeState.Completed} state`, error);
++                    //     }
++                    //     else {
++                    //         this.logger.error('Promise waiting for the connection to be complete failed.', error);
++                    //     }
++                    // });
++
++                    try{
++                        connectionRecord = await this.connectionsApi.returnWhenIsConnected(connectionRecord.id, { timeoutMs })
++                        await this.emitWithConnection(outOfBandRecord, connectionRecord, messages);
++
++                    }catch(error){
+                         if (error instanceof rxjs_1.EmptyError) {
+                             this.logger.warn(`Agent unsubscribed before connection got into ${connections_1.DidExchangeState.Completed} state`, error);
+                         }
+                         else {
+                             this.logger.error('Promise waiting for the connection to be complete failed.', error);
+                         }
+-                    });
++                    }
+                 }
+             }
+             return { outOfBandRecord, connectionRecord };

--- a/src/controllers/multi-tenancy/MultiTenancyController.ts
+++ b/src/controllers/multi-tenancy/MultiTenancyController.ts
@@ -638,6 +638,23 @@ export class MultiTenancyController extends Controller {
     }
   }
 
+  @Example<ConnectionRecordProps>(ConnectionRecordExample)
+  @Security('apiKey')
+  @Delete('/connections/:connectionId/:tenantId')
+  public async deleteConnectionById(@Path('tenantId') tenantId: string, @Path('connectionId') connectionId: RecordId) {
+    try {
+      let connectionRecord
+      await this.agent.modules.tenants.withTenantAgent({ tenantId }, async (tenantAgent) => {
+        const connection = await tenantAgent.connections.deleteById(connectionId)
+        return JsonTransformer.toJSON(connection)
+      })
+
+      return connectionRecord
+    } catch (error) {
+      throw ErrorHandlingService.handle(error)
+    }
+  }
+
   @Security('apiKey')
   @Post('/create-invitation/:tenantId')
   public async createInvitation(

--- a/src/controllers/multi-tenancy/MultiTenancyController.ts
+++ b/src/controllers/multi-tenancy/MultiTenancyController.ts
@@ -643,8 +643,7 @@ export class MultiTenancyController extends Controller {
   @Delete('/connections/:connectionId/:tenantId')
   public async deleteConnectionById(@Path('tenantId') tenantId: string, @Path('connectionId') connectionId: RecordId) {
     try {
-      let connectionRecord
-      await this.agent.modules.tenants.withTenantAgent({ tenantId }, async (tenantAgent) => {
+      const connectionRecord = await this.agent.modules.tenants.withTenantAgent({ tenantId }, async (tenantAgent) => {
         const connection = await tenantAgent.connections.deleteById(connectionId)
         return JsonTransformer.toJSON(connection)
       })


### PR DESCRIPTION
### Description

When issuing credentials using the out-of-band protocol with connection reuse disabled or when establishing a new connection, the connection gets successfully established, but the credentials remain in the request-sent state indefinitely.

This issue does not occur when reusing an existing connection. In such cases, the credential issuance process transitions to the appropriate final state as expected.

1. **Delete Connection Functionality:**
   - Implemented functionality to delete an existing connection.
   - Validates connection state before deletion to ensure data consistency.

2. **Patch for Multitenancy OOB Connection:**
   - Fixed an issue with Out-Of-Band (OOB) connections in a multitenancy environment.
   - Improved compatibility with existing multitenancy configurations.
   
  Issue created on credo-ts [Clicl here](https://github.com/openwallet-foundation/credo-ts/issues/2159)