### PR TITLE
docs: improve README with setup instructions

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,8 +1,14 @@
-# Specify connect timeout
+# Wallet connection-pool settings. These map to the wallet-connect-timeout, wallet-max-connections,
+# and wallet-idle-timeout CLI options. Prefer the AFJ_REST_WALLET_* variables; the CONNECT_TIMEOUT,
+# MAX_CONNECTIONS, and IDLE_TIMEOUT fallbacks are also supported.
+# Specify wallet connect timeout
+# AFJ_REST_WALLET_CONNECT_TIMEOUT
 CONNECT_TIMEOUT=
-# Specify max connections
+# Specify wallet max connections
+# AFJ_REST_WALLET_MAX_CONNECTIONS
 MAX_CONNECTIONS=
-# Specify idle timeout
+# Specify wallet idle timeout
+# AFJ_REST_WALLET_IDLE_TIMEOUT
 IDLE_TIMEOUT=
 #Specify max number 2147483647
 SESSION_ACQUIRE_TIMEOUT=

--- a/README.md
+++ b/README.md
@@ -44,74 +44,71 @@ The REST API provides an OpenAPI schema that can easily be viewed using the Swag
 
 Using the CLI is the easiest way to get started with the REST API.
 
-**With Docker (easiest)**
+> **Note**: The preferred operating system for development and deployment is **Ubuntu LTS (20.04 or later)**.
 
-Make sure you have [Docker](https://docs.docker.com/get-docker/) installed. To get a minimal version of the agent running the following command is sufficient:
 
-```sh
-docker run -p 5000:5000 -p 3000:3000 ghcr.io/hyperledger/afj-rest \
-  --label "AFJ Rest" \
-  --wallet-id "walletId" \
-  --wallet-key "walletKey" \
-  --endpoint http://localhost:5000 \
-  --admin-port 3000 \
-  --outbound-transport http \
-  --inbound-transport http 5000
-```
-
-See the [docker-compose.yml](https://github.com/hyperledger/aries-framework-javascript-ext/tree/main/docker-compose.yml) file for an example of using the afj-rest image with Docker Compose.
-
-> ⚠️ The Docker image is not optimized for ARM architectures and won't work on Apple Silicon Macs. See the **Directly on Computer** below on how to run it directly on your computer without Docker.
-
-**Directly on Computer**
-
-To run AFJ REST API directly on your computer you need to have the indy-sdk installed. Follow the Indy [installation steps](https://github.com/hyperledger/aries-framework-javascript/tree/main/docs/libindy) for your platform and verify Indy is installed.
-
-Once you have installed Indy, you can start the REST server using the following command:
+### Clone the Repository
 
 ```sh
-npx -p @aries-framework/rest afj-rest start \
-  --label "AFJ Rest" \
-  --wallet-id "walletId" \
-  --wallet-key "walletKey" \
-  --endpoint http://localhost:5000 \
-  --admin-port 3000 \
-  --outbound-transport http \
-  --inbound-transport http 5000
+git clone https://github.com/credebl/credo-controller.git
+cd credo-controller
 ```
 
-**Configuration**
+### Run via Docker
 
-To find out all available configuration options from the CLI, you can run the CLI command with `--help`. This will print a full list of all available options.
+#### Step 1: Create a Configuration File
 
-```sh
-# With docker
-docker run ghcr.io/hyperledger/afj-rest --help
+In the root directory of the project, create a file named `my-config.json`.
+You can base it on the sample located at `/samples/cliConfig.json`.
 
-# Directly on computer
-npx -p @aries-framework/rest afj-rest start --help
-```
-
-It is also possible to configure the REST API using a json config. When providing a lot of configuration options, this is definitely the easiest way to use configure the agent. All properties should use camelCase for the key names. See the example [CLI Config](https://github.com/hyperledger/aries-framework-javascript-ext/tree/main/packages/rest/samples/cliConfig.json) for an detailed example.
+#### Example `my-config.json`:
 
 ```json
 {
-  "label": "AFJ Rest Agent",
-  "walletId": "walletId",
-  "walletKey": "walletKey"
-  // ... other config options ... //
+  "label": "My Credo Agent",
+  "walletId": "my-wallet",
+  "walletKey": "my-secret-key",
+  "walletType": "sqlite",
+  "walletUrl": "sqlite://wallet.db",
+  "walletScheme": "ProfilePerWallet",
+  "walletAccount": "admin",
+  "walletPassword": "password",
+  "walletAdminAccount": "admin",
+  "walletAdminPassword": "admin-password",
+  "adminPort": 3000,
+  "walletConnectTimeout": 10000,
+  "walletMaxConnections": 10,
+  "walletIdleTimeout": 30000,
+  "indyLedger": [
+    {
+      "genesisTransactions": "https://raw.githubusercontent.com/bcgov/von-network/main/BCovrin/genesis_test",
+      "indyNamespace": "bcovrin:testnet"
+    }
+  ]
 }
 ```
 
-As a final option it is possible to configure the agent using environment variables. All properties are prefixed by `AFJ_REST` transformed to UPPER_SNAKE_CASE.
+> Ensure `my-config.json` is placed at the root of the project directory.
+
+> Do not commit `my-config.json` to version control. It may contain sensitive credentials.
+
+
+#### Step 2: Start the Application
+
+Run the following command from the root directory:
 
 ```sh
-# With docker
-docker run -e AFJ_REST_WALLET_KEY=my-secret-key ghcr.io/hyperledger/afj-rest ...
-
-# Directly on computer
-AFJ_REST_WALLET_KEY="my-secret-key" npx -p @aries-framework/rest afj-rest start ...
+docker run -p 3000:3000 -v "$(pwd)/my-config.json:/app/my-config.json" ghcr.io/credebl/credo-controller:latest --config /app/my-config.json
 ```
+
+This will:
+
+* Map container port `3000` to your local machine.
+* Mount the `my-config.json` configuration file into the container.
+* Start the application with the specified configuration.
+
+
+
 
 #### Starting Own Server
 
@@ -155,7 +152,7 @@ The currently supported events are:
 
 When using the CLI, a webhook url can be specified using the `--webhook-url` config option.
 
-When using the REST server as an library, the WebSocket server and webhook url can be configured in the `startServer` and `setupServer` methods.
+When using the REST server as a library, the WebSocket server and webhook url can be configured in the `startServer` and `setupServer` methods.
 
 ```ts
 // You can either call startServer() or setupServer() and pass the ServerConfig interface with a webhookUrl and/or a WebSocket server

--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 <p align="center">
   <br />
   <img
-    alt="Hyperledger Aries logo"
-    src="https://raw.githubusercontent.com/hyperledger/aries-framework-javascript/aa31131825e3331dc93694bc58414d955dcb1129/images/aries-logo.png"
+    alt="Credo logo"
+    src="https://raw.githubusercontent.com/openwallet-foundation/credo-ts/main/images/credo-logo.png"
     height="250px"
   />
 </p>
-<h1 align="center"><b>Aries Framework JavaScript REST API</b></h1>
+
+# Credo Controller REST API
+
 <p align="center">
   <a
     href="https://raw.githubusercontent.com/hyperledger/aries-framework-javascript-ext/main/LICENSE"
@@ -19,33 +21,31 @@
       alt="typescript"
       src="https://img.shields.io/badge/%3C%2F%3E-TypeScript-%230074c1.svg"
   /></a>
-    <a href="https://www.npmjs.com/package/@aries-framework/rest"
+  <a href="https://github.com/credebl/credo-controller"
     ><img
-      alt="@aries-framework/rest version"
-      src="https://img.shields.io/npm/v/@aries-framework/rest"
+      alt="GitHub"
+      src="https://img.shields.io/github/stars/credebl/credo-controller?style=social"
   /></a>
-
 </p>
 <br />
 
-The Aries Framework JavaScript REST API is the most convenient way for self-sovereign identity (SSI) developers to interact with SSI agents.
+The Credo Controller REST API is the most convenient way for self-sovereign identity (SSI) developers to interact with SSI agents.
 
 - ⭐ **Endpoints** to create connections, issue credentials, and request proofs.
 - 💻 **CLI** that makes it super easy to start an instance of the REST API.
 - 🌐 **Interoperable** with all major Aries implementations.
 
-### Quick start
+## Quick Start
 
 The REST API provides an OpenAPI schema that can easily be viewed using the SwaggerUI that is provided with the server. The docs can be viewed on the `/docs` endpoint (e.g. http://localhost:3000/docs).
 
-> The OpenAPI spec is generated from the model classes used by Aries Framework JavaScript. Due to limitations in the inspection of these classes, the generated schema does not always exactly match the expected format. Keep this in mind when using this package. If you encounter any issues, feel free to open an issue.
+> The OpenAPI spec is generated from the model classes used by Credo-TS. Due to limitations in the inspection of these classes, the generated schema does not always exactly match the expected format. Keep this in mind when using this package. If you encounter any issues, feel free to open an issue.
 
-#### Using the CLI
+### Using the CLI
 
 Using the CLI is the easiest way to get started with the REST API.
 
 > **Note**: The preferred operating system for development and deployment is **Ubuntu LTS (20.04 or later)**.
-
 
 ### Clone the Repository
 
@@ -54,79 +54,152 @@ git clone https://github.com/credebl/credo-controller.git
 cd credo-controller
 ```
 
-### Run via Docker
+## Getting Started
 
-#### Step 1: Create a Configuration File
+### Method 1: Local Development (Recommended for Development)
 
-In the root directory of the project, create a file named `my-config.json`.
-You can base it on the sample located at `/samples/cliConfig.json`.
+<details>
+<summary><strong>Local Development Setup</strong></summary>
 
-#### Example `my-config.json`:
+#### Prerequisites
+- Node.js version **18.19.0** (tested and recommended)
+- Yarn package manager
+
+> **Note**: This project requires Node.js 18.19.0. It has been tested and may not work properly with newer versions like Node.js 24.x.
+
+> **Compatibility**: While Node.js 18.19.0 is recommended, the project should also work with Node.js versions >20 (major versions). However, thorough testing is recommended when using newer Node.js versions.
+
+#### Steps
+
+1. **Install dependencies:**
+   ```sh
+   yarn install
+   ```
+
+2. **Build the project:**
+   ```sh
+   yarn build
+   ```
+
+3. **Start development server:**
+   ```sh
+   yarn dev
+   ```
+
+The application will start in development mode with hot reloading enabled.
+
+</details>
+
+### Method 2: Build and Run Local Docker Image
+
+<details>
+<summary><strong>Docker Build Instructions</strong></summary>
+
+If you want to build your own Docker image locally and run it:
+
+#### Steps
+
+1. **Build the Docker image:**
+   ```sh
+   docker build -t credo-controller:local .
+   ```
+
+2. **Run the container:**
+   ```sh
+   docker run --network host \
+     -v "$(pwd)/samples/cliConfig.json:/app/cliConfig.json" \
+     credo-controller:local --config /app/cliConfig.json
+   ```
+
+This method gives you full control over the Docker build process and allows you to customize the image as needed.
+
+> **OS Compatibility**: This containerized method has been tested and works on **WSL**, **Ubuntu**, and **Fedora**. It should work on any system with Docker support.
+
+</details>
+
+### Method 3: Using Prebuilt Docker Image with PostgreSQL
+
+<details>
+<summary><strong>PostgreSQL + Prebuilt Image Setup</strong></summary>
+
+This method uses the official prebuilt Docker image with a PostgreSQL database setup.
+
+#### Prerequisites
+
+First, you need to add these required parameters to `samples/cliConfig.json`:
 
 ```json
 {
-  "label": "My Credo Agent",
-  "walletId": "my-wallet",
-  "walletKey": "my-secret-key",
-  "walletType": "sqlite",
-  "walletUrl": "sqlite://wallet.db",
-  "walletScheme": "ProfilePerWallet",
-  "walletAccount": "admin",
-  "walletPassword": "password",
-  "walletAdminAccount": "admin",
-  "walletAdminPassword": "admin-password",
-  "adminPort": 3000,
-  "walletConnectTimeout": 10000,
-  "walletMaxConnections": 10,
-  "walletIdleTimeout": 30000,
-  "indyLedger": [
-    {
-      "genesisTransactions": "https://raw.githubusercontent.com/bcgov/von-network/main/BCovrin/genesis_test",
-      "indyNamespace": "bcovrin:testnet"
-    }
-  ]
+  // ...existing configuration...
+  "walletConnectTimeout": 30,
+  "walletMaxConnections": 90,
+  "walletIdleTimeout": 30
+  // ...rest of configuration...
 }
 ```
 
-> Ensure `my-config.json` is placed at the root of the project directory.
+> **Note**: These parameters are required to avoid wallet connection errors when using PostgreSQL.
 
-> Do not commit `my-config.json` to version control. It may contain sensitive credentials.
+#### Steps
 
+1. **Start PostgreSQL database:**
+   ```sh
+   docker run --name credo-postgres -d \
+     -e POSTGRES_DB=postgres \
+     -e POSTGRES_USER=postgres \
+     -e POSTGRES_PASSWORD=postgres \
+     -p 5432:5432 \
+     postgres:13
+   ```
 
-#### Step 2: Start the Application
+2. **Run the Credo Controller:**
+   ```sh
+   docker run --network host \
+     -v "$(pwd)/samples/cliConfig.json:/app/cliConfig.json" \
+     ghcr.io/credebl/credo-controller:latest \
+     --config /app/cliConfig.json
+   ```
 
-Run the following command from the root directory:
+This method uses the official prebuilt image and connects to your local PostgreSQL instance.
 
-```sh
-docker run -p 3000:3000 -v "$(pwd)/my-config.json:/app/my-config.json" ghcr.io/credebl/credo-controller:latest --config /app/my-config.json
-```
+> **OS Compatibility**: This containerized method has been tested and works on **WSL**, **Ubuntu**, and **Fedora**. It should work on any system with Docker support.
 
-This will:
+#### Alternative: Using .env File
 
-* Map container port `3000` to your local machine.
-* Mount the `my-config.json` configuration file into the container.
-* Start the application with the specified configuration.
+The repository includes an agent environment sample file. For a quick start:
 
+1. **Rename the sample environment file:**
+   ```sh
+   cp .env.sample .env  # (if available in the repository)
+   ```
 
+2. **Run using the binary directly:**
+   ```sh
+   yarn build
+   ./bin/afj-rest.js --config ./samples/cliConfig.json
+   ```
 
+</details>
 
-#### Starting Own Server
+## Development
+
+### Starting Your Own Server
 
 Starting your own server is more involved than using the CLI, but allows more fine-grained control over the settings and allows you to extend the REST API with custom endpoints.
 
 You can create an agent instance and import the `startServer` method from the `rest` package. That's all you have to do.
 
 ```ts
-import { startServer } from '@aries-framework/rest'
-import { Agent } from '@aries-framework/core'
-import { agentDependencies } from '@aries-framework/node'
+import { startServer } from '@credo-ts/rest'
+import { Agent } from '@credo-ts/core'
+import { agentDependencies } from '@credo-ts/node'
 
 // The startServer function requires an initialized agent and a port.
 // An example of how to setup an agent is located in the `samples` directory.
 const run = async () => {
   const agent = new Agent(
     {
-      // ... AFJ Config ... //
+      // ... Credo Config ... //
     },
     agentDependencies
   )
@@ -137,7 +210,7 @@ const run = async () => {
 run()
 ```
 
-### WebSocket & webhooks
+### WebSocket & Webhooks
 
 The REST API provides the option to connect as a client and receive events emitted from your agent using WebSocket and webhooks.
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 <p align="center">
   <br />
   <img
-    alt="Credo logo"
-    src="https://raw.githubusercontent.com/openwallet-foundation/credo-ts/main/images/credo-logo.png"
-    height="250px"
+    alt="CREDEBL logo"
+    src="https://raw.githubusercontent.com/credebl/.github/main/logo.svg"
+    height="150px"
   />
 </p>
 
@@ -11,7 +11,7 @@
 
 <p align="center">
   <a
-    href="https://raw.githubusercontent.com/hyperledger/aries-framework-javascript-ext/main/LICENSE"
+    href="https://raw.githubusercontent.com/credebl/agent-controller/main/LICENSE"
     ><img
       alt="License"
       src="https://img.shields.io/badge/License-Apache%202.0-blue.svg"
@@ -21,10 +21,10 @@
       alt="typescript"
       src="https://img.shields.io/badge/%3C%2F%3E-TypeScript-%230074c1.svg"
   /></a>
-  <a href="https://github.com/credebl/credo-controller"
+  <a href="https://github.com/credebl/agent-controller"
     ><img
       alt="GitHub"
-      src="https://img.shields.io/github/stars/credebl/credo-controller?style=social"
+      src="https://img.shields.io/github/stars/credebl/agent-controller?style=social"
   /></a>
 </p>
 <br />
@@ -37,7 +37,7 @@ The Credo Controller REST API is the most convenient way for self-sovereign iden
 
 ## Quick Start
 
-The REST API provides an OpenAPI schema that can easily be viewed using the SwaggerUI that is provided with the server. The docs can be viewed on the `/docs` endpoint (e.g. http://localhost:3000/docs).
+The REST API provides an OpenAPI schema that can easily be viewed using the SwaggerUI that is provided with the server. The docs can be viewed on the `/docs` endpoint (e.g. http://localhost:4001/docs, where `4001` is the admin port configured in `samples/cliConfig.json`).
 
 > The OpenAPI spec is generated from the model classes used by Credo-TS. Due to limitations in the inspection of these classes, the generated schema does not always exactly match the expected format. Keep this in mind when using this package. If you encounter any issues, feel free to open an issue.
 
@@ -50,8 +50,8 @@ Using the CLI is the easiest way to get started with the REST API.
 ### Clone the Repository
 
 ```sh
-git clone https://github.com/credebl/credo-controller.git
-cd credo-controller
+git clone https://github.com/credebl/agent-controller.git
+cd agent-controller
 ```
 
 ## Getting Started
@@ -62,21 +62,22 @@ cd credo-controller
 <summary><strong>Local Development Setup</strong></summary>
 
 #### Prerequisites
-- Node.js version **18.19.0** (tested and recommended)
+
+- Node.js version **20 (LTS)** (tested and recommended)
 - Yarn package manager
 
-> **Note**: This project requires Node.js 18.19.0. It has been tested and may not work properly with newer versions like Node.js 24.x.
-
-> **Compatibility**: While Node.js 18.19.0 is recommended, the project should also work with Node.js versions >20 (major versions). However, thorough testing is recommended when using newer Node.js versions.
+> **Note**: Node.js 20 (LTS) is used in CI and is the recommended version. The Docker image builds and runs on Node.js 22, so newer LTS versions should also work, but thorough testing is recommended before using them.
 
 #### Steps
 
 1. **Install dependencies:**
+
    ```sh
    yarn install
    ```
 
 2. **Build the project:**
+
    ```sh
    yarn build
    ```
@@ -100,6 +101,7 @@ If you want to build your own Docker image locally and run it:
 #### Steps
 
 1. **Build the Docker image:**
+
    ```sh
    docker build -t credo-controller:local .
    ```
@@ -113,7 +115,17 @@ If you want to build your own Docker image locally and run it:
 
 This method gives you full control over the Docker build process and allows you to customize the image as needed.
 
-> **OS Compatibility**: This containerized method has been tested and works on **WSL**, **Ubuntu**, and **Fedora**. It should work on any system with Docker support.
+> **OS Compatibility**: This containerized method has been tested and works on **WSL**, **Ubuntu**, and **Fedora**.
+>
+> `--network host` is Linux-only. On **macOS / Windows (Docker Desktop)** use port mapping instead:
+>
+> ```sh
+> docker run -p 4001:4001 -p 4002:4002 \
+>   -v "$(pwd)/samples/cliConfig.json:/app/cliConfig.json" \
+>   credo-controller:local --config /app/cliConfig.json
+> ```
+>
+> When using port mapping, set `walletUrl` to `host.docker.internal:5432` in the config so the container can reach a PostgreSQL instance running on your host.
 
 </details>
 
@@ -126,23 +138,22 @@ This method uses the official prebuilt Docker image with a PostgreSQL database s
 
 #### Prerequisites
 
-First, you need to add these required parameters to `samples/cliConfig.json`:
+The `samples/cliConfig.json` file must reference a PostgreSQL wallet (it already uses `walletType: "postgres"`). Optionally, you can tune the connection pool by adding these settings:
 
 ```json
 {
-  // ...existing configuration...
   "walletConnectTimeout": 30,
   "walletMaxConnections": 90,
   "walletIdleTimeout": 30
-  // ...rest of configuration...
 }
 ```
 
-> **Note**: These parameters are required to avoid wallet connection errors when using PostgreSQL.
+> **Note**: These settings are optional connection-pool tunables for the PostgreSQL wallet. They map to the `wallet-connect-timeout`, `wallet-max-connections`, and `wallet-idle-timeout` CLI options (or the `CONNECT_TIMEOUT`, `MAX_CONNECTIONS`, and `IDLE_TIMEOUT` environment variables). They are not required for the agent to start.
 
 #### Steps
 
 1. **Start PostgreSQL database:**
+
    ```sh
    docker run --name credo-postgres -d \
      -e POSTGRES_DB=postgres \
@@ -162,13 +173,25 @@ First, you need to add these required parameters to `samples/cliConfig.json`:
 
 This method uses the official prebuilt image and connects to your local PostgreSQL instance.
 
-> **OS Compatibility**: This containerized method has been tested and works on **WSL**, **Ubuntu**, and **Fedora**. It should work on any system with Docker support.
+> **OS Compatibility**: This containerized method has been tested and works on **WSL**, **Ubuntu**, and **Fedora**.
+>
+> `--network host` is Linux-only. On **macOS / Windows (Docker Desktop)** use port mapping instead:
+>
+> ```sh
+> docker run -p 4001:4001 -p 4002:4002 \
+>   -v "$(pwd)/samples/cliConfig.json:/app/cliConfig.json" \
+>   ghcr.io/credebl/credo-controller:latest \
+>   --config /app/cliConfig.json
+> ```
+>
+> When using port mapping, set `walletUrl` to `host.docker.internal:5432` in the config so the container can reach the PostgreSQL instance running on your host.
 
 #### Alternative: Using .env File
 
 The repository includes an agent environment sample file. For a quick start:
 
 1. **Rename the sample environment file:**
+
    ```sh
    cp .env.sample .env  # (if available in the repository)
    ```
@@ -179,7 +202,26 @@ The repository includes an agent environment sample file. For a quick start:
    ./bin/afj-rest.js --config ./samples/cliConfig.json
    ```
 
+> **Note**: `afj-rest.js` is the legacy binary name, kept for backward compatibility. The CLI entrypoint is defined in the `bin` field of `package.json`.
+
 </details>
+
+## Configuration
+
+The agent can be configured in three ways:
+
+1. **CLI options**: Run the CLI with `--help` to print the full list of available options.
+
+   ```sh
+   # With Docker
+   docker run ghcr.io/credebl/credo-controller:latest --help
+
+   # Directly on computer
+   ./bin/afj-rest.js start --help
+   ```
+
+2. **JSON config file**: When providing a lot of configuration options, pass a JSON file with `--config`. All properties should use camelCase for the key names. See [samples/cliConfig.json](samples/cliConfig.json) for a complete example.
+3. **Environment variables**: All properties are prefixed with `AFJ_REST` and use UPPER_SNAKE_CASE (e.g. `AFJ_REST_WALLET_KEY=my-secret-key ./bin/afj-rest.js start ...`).
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
   />
 </p>
 
-# Credo Controller REST API
+# Agent Controller REST API
 
 <p align="center">
   <a
@@ -29,7 +29,7 @@
 </p>
 <br />
 
-The Credo Controller REST API is the most convenient way for self-sovereign identity (SSI) developers to interact with SSI agents.
+The Agent Controller REST API is the most convenient way for self-sovereign identity (SSI) developers to interact with SSI agents.
 
 - ⭐ **Endpoints** to create connections, issue credentials, and request proofs.
 - 💻 **CLI** that makes it super easy to start an instance of the REST API.
@@ -103,14 +103,14 @@ If you want to build your own Docker image locally and run it:
 1. **Build the Docker image:**
 
    ```sh
-   docker build -t credo-controller:local .
+   docker build -t agent-controller:local .
    ```
 
 2. **Run the container:**
    ```sh
    docker run --network host \
      -v "$(pwd)/samples/cliConfig.json:/app/cliConfig.json" \
-     credo-controller:local --config /app/cliConfig.json
+     agent-controller:local --config /app/cliConfig.json
    ```
 
 This method gives you full control over the Docker build process and allows you to customize the image as needed.
@@ -122,7 +122,7 @@ This method gives you full control over the Docker build process and allows you 
 > ```sh
 > docker run -p 4001:4001 -p 4002:4002 \
 >   -v "$(pwd)/samples/cliConfig.json:/app/cliConfig.json" \
->   credo-controller:local --config /app/cliConfig.json
+>   agent-controller:local --config /app/cliConfig.json
 > ```
 >
 > When using port mapping, set `walletUrl` to `host.docker.internal:5432` in the config so the container can reach a PostgreSQL instance running on your host.
@@ -155,7 +155,7 @@ The `samples/cliConfig.json` file must reference a PostgreSQL wallet (it already
 1. **Start PostgreSQL database:**
 
    ```sh
-   docker run --name credo-postgres -d \
+   docker run --name agent-controller-postgres -d \
      -e POSTGRES_DB=postgres \
      -e POSTGRES_USER=postgres \
      -e POSTGRES_PASSWORD=postgres \
@@ -163,7 +163,7 @@ The `samples/cliConfig.json` file must reference a PostgreSQL wallet (it already
      postgres:13
    ```
 
-2. **Run the Credo Controller:**
+2. **Run the Agent Controller:**
    ```sh
    docker run --network host \
      -v "$(pwd)/samples/cliConfig.json:/app/cliConfig.json" \
@@ -172,6 +172,8 @@ The `samples/cliConfig.json` file must reference a PostgreSQL wallet (it already
    ```
 
 This method uses the official prebuilt image and connects to your local PostgreSQL instance.
+
+> **Note**: The Docker image is still published under the legacy name `ghcr.io/credebl/credo-controller`. The prebuilt image and `docker compose` entry points have not yet been renamed to match the new "Agent Controller" project name.
 
 > **OS Compatibility**: This containerized method has been tested and works on **WSL**, **Ubuntu**, and **Fedora**.
 >
@@ -241,7 +243,7 @@ import { agentDependencies } from '@credo-ts/node'
 const run = async () => {
   const agent = new Agent(
     {
-      // ... Credo Config ... //
+      // ... Agent Config ... //
     },
     agentDependencies
   )

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ The `samples/cliConfig.json` file must reference a PostgreSQL wallet (it already
 }
 ```
 
-> **Note**: These settings are optional connection-pool tunables for the PostgreSQL wallet. They map to the `wallet-connect-timeout`, `wallet-max-connections`, and `wallet-idle-timeout` CLI options (or the `CONNECT_TIMEOUT`, `MAX_CONNECTIONS`, and `IDLE_TIMEOUT` environment variables). They are not required for the agent to start.
+> **Note**: These settings are optional connection-pool tunables for the PostgreSQL wallet. They map to the `wallet-connect-timeout`, `wallet-max-connections`, and `wallet-idle-timeout` CLI options, the `AFJ_REST_WALLET_CONNECT_TIMEOUT`, `AFJ_REST_WALLET_MAX_CONNECTIONS`, and `AFJ_REST_WALLET_IDLE_TIMEOUT` environment variables, or the `CONNECT_TIMEOUT`, `MAX_CONNECTIONS`, and `IDLE_TIMEOUT` environment-variable fallbacks. They are not required for the agent to start.
 
 #### Steps
 
@@ -160,7 +160,7 @@ The `samples/cliConfig.json` file must reference a PostgreSQL wallet (it already
      -e POSTGRES_USER=postgres \
      -e POSTGRES_PASSWORD=postgres \
      -p 5432:5432 \
-     postgres:13
+     postgres:16
    ```
 
 2. **Run the Agent Controller:**
@@ -174,7 +174,7 @@ The `samples/cliConfig.json` file must reference a PostgreSQL wallet (it already
 This method uses the official prebuilt image and connects to your local PostgreSQL instance.
 
 > **Note**: The Docker image is still published under the legacy name `ghcr.io/credebl/credo-controller`. The prebuilt image and `docker compose` entry points have not yet been renamed to match the new "Agent Controller" project name.
-
+>
 > **OS Compatibility**: This containerized method has been tested and works on **WSL**, **Ubuntu**, and **Fedora**.
 >
 > `--network host` is Linux-only. On **macOS / Windows (Docker Desktop)** use port mapping instead:
@@ -245,8 +245,9 @@ const run = async () => {
     {
       // ... Agent Config ... //
     },
-    agentDependencies
+    agentDependencies,
   )
+  await agent.initialize()
   await startServer(agent, { port: 3000 })
 }
 


### PR DESCRIPTION
This pull request updates the README.md file to improve clarity and correctness of the setup instructions.

Changes Made
- Removed outdated or incorrect installation instructions.
- Added correct steps for setting up the project via Docker using a configuration file.
- Included a complete sample my-config.json.
- Added a note specifying Ubuntu LTS (20.04 or later) as the preferred OS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Rebranded the project as the Agent Controller REST API and updated repository references.
  * Expanded setup instructions for local development, Docker, PostgreSQL, environment variables, and CLI usage.
  * Updated configuration examples to use Credo-TS packages and repository-local files.
  * Clarified Docker networking, JSON configuration, PostgreSQL wallet settings, WebSocket and webhook terminology, and general grammar.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->