### PR TITLE
fix: proof controller

### DIFF
--- a/src/controllers/didcomm/proofs/ProofController.ts
+++ b/src/controllers/didcomm/proofs/ProofController.ts
@@ -79,7 +79,7 @@ export class ProofController extends Controller {
     try {
       const proof = await request.agent.modules.didcomm.proofs.proposeProof({
         connectionId: requestProofProposalOptions.connectionId,
-        protocolVersion: 'v1' as ProofsProtocolVersionType<[]>,
+        protocolVersion: requestProofProposalOptions.protocolVersion as ProofsProtocolVersionType<[]>,
         proofFormats: requestProofProposalOptions.proofFormats,
         comment: requestProofProposalOptions.comment,
         autoAcceptProof: requestProofProposalOptions.autoAcceptProof,
@@ -101,7 +101,7 @@ export class ProofController extends Controller {
    * @param proposal
    * @returns ProofRecord
    */
-  @Post('/:proofRecordId/accept-proposal')
+  @Post('/accept-proposal')
   @Example<DidCommProofExchangeRecordProps>(ProofRecordExample)
   public async acceptProposal(@Request() request: Req, @Body() acceptProposal: AcceptProofProposal) {
     try {
@@ -199,7 +199,7 @@ export class ProofController extends Controller {
           useDidSovPrefixWhereAllowed: request.agent.modules.didcomm.config.useDidSovPrefixWhereAllowed,
         }),
         outOfBandRecord: outOfBandRecord.toJSON(),
-        invitationDid: createRequestOptions?.invitationDid ? '' : invitationDid,
+        invitationDid,
         proofRecordThId: proof.proofRecord.threadId,
         proofMessageId: proof.message.thread?.threadId || proof.message.threadId || proof.message.id,
       }
@@ -223,6 +223,7 @@ export class ProofController extends Controller {
     @Path('proofRecordId') proofRecordId: string,
     @Body()
     body: {
+      // TODO: Check if we can remove the below body options as they are not used
       filterByPresentationPreview?: boolean
       filterByNonRevocationRequirements?: boolean
       comment?: string

--- a/src/controllers/didcomm/proofs/ProofController.ts
+++ b/src/controllers/didcomm/proofs/ProofController.ts
@@ -1,283 +1,285 @@
-// import type {
-//   PeerDidNumAlgo2CreateOptions,
-// } from '@credo-ts/core'
+import type {
+  PeerDidNumAlgo2CreateOptions,
+} from '@credo-ts/core'
 
-// import {
-//   AcceptProofRequestOptions,
-//   ProofExchangeRecordProps,
-//   ProofsProtocolVersionType,
-//   Routing,
-// } from '@credo-ts/didcomm'
+import {
+  AcceptProofRequestOptions,
+  DidCommProofExchangeRecordProps,
+  ProofsProtocolVersionType,
+  DidCommRouting,
+} from '@credo-ts/didcomm'
 
-// import { PeerDidNumAlgo, createPeerDidDocumentFromServices } from '@credo-ts/core'
-// import { Request as Req } from 'express'
-// import { Body, Controller, Example, Get, Path, Post, Query, Route, Tags, Security, Request } from 'tsoa'
-// import { injectable } from 'tsyringe'
+import { PeerDidNumAlgo, createPeerDidDocumentFromServices } from '@credo-ts/core'
+import { Request as Req } from 'express'
+import { Body, Controller, Example, Get, Path, Post, Query, Route, Tags, Security, Request } from 'tsoa'
+import { injectable } from 'tsyringe'
 
-// import { SCOPES } from '../../../enums'
-// import ErrorHandlingService from '../../../errorHandlingService'
-// import { ProofRecordExample, RecordId } from '../../examples'
-// import {
-//   AcceptProofProposal,
-//   CreateProofRequestOobOptions,
-//   RequestProofOptions,
-//   RequestProofProposalOptions,
-// } from '../../types'
+import { SCOPES } from '../../../enums'
+import ErrorHandlingService from '../../../errorHandlingService'
+import { ProofRecordExample, RecordId } from '../../examples'
+import {
+  AcceptProofProposal,
+  CreateProofRequestOobOptions,
+  RequestProofOptions,
+  RequestProofProposalOptions,
+} from '../../types'
 
-// @Tags('DIDComm - Proofs')
-// @Route('/didcomm/proofs')
-// @Security('jwt', [SCOPES.TENANT_AGENT, SCOPES.DEDICATED_AGENT])
-// @injectable()
-// export class ProofController extends Controller {
-//   /**
-//    * Retrieve all proof records
-//    *
-//    * @param threadId
-//    * @returns ProofRecord[]
-//    */
-//   @Example<ProofExchangeRecordProps[]>([ProofRecordExample])
-//   @Get('/')
-//   public async getAllProofs(@Request() request: Req, @Query('threadId') threadId?: string) {
-//     try {
-//       const query = threadId ? { threadId } : {}
-//       const proofs = await request.agent.modules.proofs.findAllByQuery(query)
+@Tags('DIDComm - Proofs')
+@Route('/didcomm/proofs')
+@Security('jwt', [SCOPES.TENANT_AGENT, SCOPES.DEDICATED_AGENT])
+@injectable()
+export class ProofController extends Controller {
+  /**
+   * Retrieve all proof records
+   *
+   * @param threadId
+   * @returns ProofRecord[]
+   */
+  @Example<DidCommProofExchangeRecordProps[]>([ProofRecordExample])
+  @Get('/')
+  public async getAllProofs(@Request() request: Req, @Query('threadId') threadId?: string) {
+    try {
+      const query = threadId ? { threadId } : {}
+      const proofs = await request.agent.modules.didcomm.proofs.findAllByQuery(query)
 
-//       return proofs.map((proof) => proof.toJSON())
-//     } catch (error) {
-//       throw ErrorHandlingService.handle(error)
-//     }
-//   }
+      return proofs.map((proof) => proof.toJSON())
+    } catch (error) {
+      throw ErrorHandlingService.handle(error)
+    }
+  }
 
-//   /**
-//    * Retrieve proof record by proof record id
-//    *
-//    * @param proofRecordId
-//    * @returns ProofRecord
-//    */
-//   @Get('/:proofRecordId')
-//   @Example<ProofExchangeRecordProps>(ProofRecordExample)
-//   public async getProofById(@Request() request: Req, @Path('proofRecordId') proofRecordId: RecordId) {
-//     try {
-//       const proof = await request.agent.modules.proofs.getById(proofRecordId)
+  /**
+   * Retrieve proof record by proof record id
+   *
+   * @param proofRecordId
+   * @returns ProofRecord
+   */
+  @Get('/:proofRecordId')
+  @Example<DidCommProofExchangeRecordProps>(ProofRecordExample)
+  public async getProofById(@Request() request: Req, @Path('proofRecordId') proofRecordId: RecordId) {
+    try {
+      const proof = await request.agent.modules.didcomm.proofs.getById(proofRecordId)
 
-//       return proof.toJSON()
-//     } catch (error) {
-//       throw ErrorHandlingService.handle(error)
-//     }
-//   }
+      return proof.toJSON()
+    } catch (error) {
+      throw ErrorHandlingService.handle(error)
+    }
+  }
 
-//   /**
-//    * Initiate a new presentation exchange as prover by sending a presentation proposal request
-//    * to the connection with the specified connection id.
-//    *
-//    * @param proposal
-//    * @returns ProofRecord
-//    */
-//   @Post('/propose-proof')
-//   @Example<ProofExchangeRecordProps>(ProofRecordExample)
-//   public async proposeProof(@Request() request: Req, @Body() requestProofProposalOptions: RequestProofProposalOptions) {
-//     try {
-//       const proof = await request.agent.modules.proofs.proposeProof({
-//         connectionId: requestProofProposalOptions.connectionId,
-//         protocolVersion: 'v1' as ProofsProtocolVersionType<[]>,
-//         proofFormats: requestProofProposalOptions.proofFormats,
-//         comment: requestProofProposalOptions.comment,
-//         autoAcceptProof: requestProofProposalOptions.autoAcceptProof,
-//         goalCode: requestProofProposalOptions.goalCode,
-//         parentThreadId: requestProofProposalOptions.parentThreadId,
-//       })
+  /**
+   * Initiate a new presentation exchange as prover by sending a presentation proposal request
+   * to the connection with the specified connection id.
+   *
+   * @param proposal
+   * @returns ProofRecord
+   */
+  @Post('/propose-proof')
+  @Example<DidCommProofExchangeRecordProps>(ProofRecordExample)
+  public async proposeProof(@Request() request: Req, @Body() requestProofProposalOptions: RequestProofProposalOptions) {
+    try {
+      const proof = await request.agent.modules.didcomm.proofs.proposeProof({
+        connectionId: requestProofProposalOptions.connectionId,
+        protocolVersion: 'v1' as ProofsProtocolVersionType<[]>,
+        proofFormats: requestProofProposalOptions.proofFormats,
+        comment: requestProofProposalOptions.comment,
+        autoAcceptProof: requestProofProposalOptions.autoAcceptProof,
+        goalCode: requestProofProposalOptions.goalCode,
+        parentThreadId: requestProofProposalOptions.parentThreadId,
+      })
 
-//       return proof
-//     } catch (error) {
-//       throw ErrorHandlingService.handle(error)
-//     }
-//   }
+      return proof
+    } catch (error) {
+      throw ErrorHandlingService.handle(error)
+    }
+  }
 
-//   /**
-//    * Accept a presentation proposal as verifier by sending an accept proposal message
-//    * to the connection associated with the proof record.
-//    *
-//    * @param proofRecordId
-//    * @param proposal
-//    * @returns ProofRecord
-//    */
-//   @Post('/:proofRecordId/accept-proposal')
-//   @Example<ProofExchangeRecordProps>(ProofRecordExample)
-//   public async acceptProposal(@Request() request: Req, @Body() acceptProposal: AcceptProofProposal) {
-//     try {
-//       const proof = await request.agent.modules.proofs.acceptProposal(acceptProposal)
+  /**
+   * Accept a presentation proposal as verifier by sending an accept proposal message
+   * to the connection associated with the proof record.
+   *
+   * @param proofRecordId
+   * @param proposal
+   * @returns ProofRecord
+   */
+  @Post('/:proofRecordId/accept-proposal')
+  @Example<DidCommProofExchangeRecordProps>(ProofRecordExample)
+  public async acceptProposal(@Request() request: Req, @Body() acceptProposal: AcceptProofProposal) {
+    try {
+      const proof = await request.agent.modules.didcomm.proofs.acceptProposal(acceptProposal)
 
-//       return proof
-//     } catch (error) {
-//       throw ErrorHandlingService.handle(error)
-//     }
-//   }
+      return proof
+    } catch (error) {
+      throw ErrorHandlingService.handle(error)
+    }
+  }
 
-//   /**
-//    * Creates a presentation request bound to existing connection
-//    */
-//   @Post('/request-proof')
-//   @Example<ProofExchangeRecordProps>(ProofRecordExample)
-//   public async requestProof(@Request() request: Req, @Body() requestProofOptions: RequestProofOptions) {
-//     try {
-//       const requestProofPayload = {
-//         connectionId: requestProofOptions.connectionId,
-//         protocolVersion: requestProofOptions.protocolVersion as ProofsProtocolVersionType<[]>,
-//         comment: requestProofOptions.comment,
-//         proofFormats: requestProofOptions.proofFormats,
-//         autoAcceptProof: requestProofOptions.autoAcceptProof,
-//         goalCode: requestProofOptions.goalCode,
-//         parentThreadId: requestProofOptions.parentThreadId,
-//         willConfirm: requestProofOptions.willConfirm,
-//       }
-//       const proof = await request.agent.modules.proofs.requestProof(requestProofPayload)
+  /**
+   * Creates a presentation request bound to existing connection
+   */
+  @Post('/request-proof')
+  @Example<DidCommProofExchangeRecordProps>(ProofRecordExample)
+  public async requestProof(@Request() request: Req, @Body() requestProofOptions: RequestProofOptions) {
+    try {
+      const requestProofPayload = {
+        connectionId: requestProofOptions.connectionId,
+        protocolVersion: requestProofOptions.protocolVersion as ProofsProtocolVersionType<[]>,
+        comment: requestProofOptions.comment,
+        proofFormats: requestProofOptions.proofFormats,
+        autoAcceptProof: requestProofOptions.autoAcceptProof,
+        goalCode: requestProofOptions.goalCode,
+        parentThreadId: requestProofOptions.parentThreadId,
+        willConfirm: requestProofOptions.willConfirm,
+      }
+      const proof = await request.agent.modules.didcomm.proofs.requestProof(requestProofPayload)
 
-//       return proof
-//     } catch (error) {
-//       throw ErrorHandlingService.handle(error)
-//     }
-//   }
+      return proof
+    } catch (error) {
+      throw ErrorHandlingService.handle(error)
+    }
+  }
 
-//   /**
-//    * Creates a presentation request not bound to any proposal or existing connection
-//    */
-//   @Post('create-request-oob')
-//   @Example<ProofExchangeRecordProps>(ProofRecordExample)
-//   public async createRequest(@Request() request: Req, @Body() createRequestOptions: CreateProofRequestOobOptions) {
-//     try {
-//       let routing: Routing
-//       let invitationDid: string | undefined
+  /**
+   * Creates a presentation request not bound to any proposal or existing connection
+   */
+  @Post('create-request-oob')
+  @Example<DidCommProofExchangeRecordProps>(ProofRecordExample)
+  public async createRequest(@Request() request: Req, @Body() createRequestOptions: CreateProofRequestOobOptions) {
+    try {
+      let routing: DidCommRouting
+      let invitationDid: string | undefined
 
-//       if (createRequestOptions?.invitationDid) {
-//         invitationDid = createRequestOptions?.invitationDid
-//       } else {
-//         routing = await request.agent.modules.mediationRecipient.getRouting({})
-//         const didDocument = createPeerDidDocumentFromServices([
-//           {
-//             id: 'didcomm',
-//             recipientKeys: [routing.recipientKey],
-//             routingKeys: routing.routingKeys,
-//             serviceEndpoint: routing.endpoints[0],
-//           },
-//         ])
-//         const did = await request.agent.dids.create<PeerDidNumAlgo2CreateOptions>({
-//           didDocument,
-//           method: 'peer',
-//           options: {
-//             numAlgo: PeerDidNumAlgo.MultipleInceptionKeyWithoutDoc,
-//           },
-//         })
-//         invitationDid = did.didState.did
-//       }
+      if (createRequestOptions?.invitationDid) {
+        invitationDid = createRequestOptions?.invitationDid
+      } else {
+        routing = await request.agent.modules.didcomm.mediationRecipient.getRouting({})
+        const {didDocument, keys} = createPeerDidDocumentFromServices([
+          {
+            id: 'didcomm',
+            recipientKeys: [routing.recipientKey],
+            routingKeys: routing.routingKeys,
+            serviceEndpoint: routing.endpoints[0],
+          }
+        ],
+        true)
+        const did = await request.agent.dids.create<PeerDidNumAlgo2CreateOptions>({
+          didDocument,
+          method: 'peer',
+          options: {
+            numAlgo: PeerDidNumAlgo.MultipleInceptionKeyWithoutDoc,
+            keys
+          },
+        })
+        invitationDid = did.didState.did
+      }
 
-//       const proof = await request.agent.modules.proofs.createRequest({
-//         protocolVersion: createRequestOptions.protocolVersion as ProofsProtocolVersionType<[]>,
-//         proofFormats: createRequestOptions.proofFormats,
-//         goalCode: createRequestOptions.goalCode,
-//         willConfirm: createRequestOptions.willConfirm,
-//         parentThreadId: createRequestOptions.parentThreadId,
-//         autoAcceptProof: createRequestOptions.autoAcceptProof,
-//         comment: createRequestOptions.comment,
-//       })
-//       const proofMessage = proof.message
-//       const outOfBandRecord = await request.agent.modules.oob.createInvitation({
-//         label: createRequestOptions.label,
-//         messages: [proofMessage],
-//         autoAcceptConnection: true,
-//         imageUrl: createRequestOptions?.imageUrl,
-//         goalCode: createRequestOptions?.goalCode,
-//         invitationDid,
-//       })
+      const proof = await request.agent.modules.didcomm.proofs.createRequest({
+        protocolVersion: createRequestOptions.protocolVersion as ProofsProtocolVersionType<[]>,
+        proofFormats: createRequestOptions.proofFormats,
+        goalCode: createRequestOptions.goalCode,
+        willConfirm: createRequestOptions.willConfirm,
+        parentThreadId: createRequestOptions.parentThreadId,
+        autoAcceptProof: createRequestOptions.autoAcceptProof,
+        comment: createRequestOptions.comment,
+      })
+      const proofMessage = proof.message
+      const outOfBandRecord = await request.agent.modules.didcomm.oob.createInvitation({
+        label: createRequestOptions.label,
+        messages: [proofMessage],
+        autoAcceptConnection: true,
+        imageUrl: createRequestOptions?.imageUrl,
+        goalCode: createRequestOptions?.goalCode,
+        invitationDid,
+      })
 
-//       return {
-//         invitationUrl: outOfBandRecord.outOfBandInvitation.toUrl({
-//           domain: request.agent.modules.didcomm.config.endpoints[0],
-//         }),
-//         invitation: outOfBandRecord.outOfBandInvitation.toJSON({
-//           useDidSovPrefixWhereAllowed: request.agent.modules.didcomm.config.useDidSovPrefixWhereAllowed,
-//         }),
-//         outOfBandRecord: outOfBandRecord.toJSON(),
-//         invitationDid: createRequestOptions?.invitationDid ? '' : invitationDid,
-//         proofRecordThId: proof.proofRecord.threadId,
-//         proofMessageId: proof.message.thread?.threadId || proof.message.threadId || proof.message.id,
-//       }
-//     } catch (error) {
-//       throw ErrorHandlingService.handle(error)
-//     }
-//   }
+      return {
+        invitationUrl: outOfBandRecord.outOfBandInvitation.toUrl({
+          domain: request.agent.modules.didcomm.config.endpoints[0],
+        }),
+        invitation: outOfBandRecord.outOfBandInvitation.toJSON({
+          useDidSovPrefixWhereAllowed: request.agent.modules.didcomm.config.useDidSovPrefixWhereAllowed,
+        }),
+        outOfBandRecord: outOfBandRecord.toJSON(),
+        invitationDid: createRequestOptions?.invitationDid ? '' : invitationDid,
+        proofRecordThId: proof.proofRecord.threadId,
+        proofMessageId: proof.message.thread?.threadId || proof.message.threadId || proof.message.id,
+      }
+    } catch (error) {
+      throw ErrorHandlingService.handle(error)
+    }
+  }
 
-//   /**
-//    * Accept a presentation request as prover by sending an accept request message
-//    * to the connection associated with the proof record.
-//    *
-//    * @param proofRecordId
-//    * @param request
-//    * @returns ProofRecord
-//    */
-//   @Post('/:proofRecordId/accept-request')
-//   @Example<ProofExchangeRecordProps>(ProofRecordExample)
-//   public async acceptRequest(
-//     @Request() request: Req,
-//     @Path('proofRecordId') proofRecordId: string,
-//     @Body()
-//     body: {
-//       filterByPresentationPreview?: boolean
-//       filterByNonRevocationRequirements?: boolean
-//       comment?: string
-//     },
-//   ) {
-//     try {
-//       const requestedCredentials = await request.agent.modules.proofs.selectCredentialsForRequest({
-//         proofRecordId,
-//       })
+  /**
+   * Accept a presentation request as prover by sending an accept request message
+   * to the connection associated with the proof record.
+   *
+   * @param proofRecordId
+   * @param request
+   * @returns ProofRecord
+   */
+  @Post('/:proofRecordId/accept-request')
+  @Example<DidCommProofExchangeRecordProps>(ProofRecordExample)
+  public async acceptRequest(
+    @Request() request: Req,
+    @Path('proofRecordId') proofRecordId: string,
+    @Body()
+    body: {
+      filterByPresentationPreview?: boolean
+      filterByNonRevocationRequirements?: boolean
+      comment?: string
+    },
+  ) {
+    try {
+      const requestedCredentials = await request.agent.modules.didcomm.proofs.selectCredentialsForRequest({
+        proofExchangeRecordId: proofRecordId,
+      })
 
-//       const acceptProofRequest: AcceptProofRequestOptions = {
-//         proofRecordId,
-//         comment: body.comment,
-//         proofFormats: requestedCredentials.proofFormats,
-//       }
+      const acceptProofRequest: AcceptProofRequestOptions = {
+        proofExchangeRecordId: proofRecordId,
+        comment: body.comment,
+        proofFormats: requestedCredentials.proofFormats,
+      }
 
-//       const proof = await request.agent.modules.proofs.acceptRequest(acceptProofRequest)
+      const proof = await request.agent.modules.didcomm.proofs.acceptRequest(acceptProofRequest)
 
-//       return proof.toJSON()
-//     } catch (error) {
-//       throw ErrorHandlingService.handle(error)
-//     }
-//   }
+      return proof.toJSON()
+    } catch (error) {
+      throw ErrorHandlingService.handle(error)
+    }
+  }
 
-//   /**
-//    * Accept a presentation as prover by sending an accept presentation message
-//    * to the connection associated with the proof record.
-//    *
-//    * @param proofRecordId
-//    * @returns ProofRecord
-//    */
-//   @Post('/:proofRecordId/accept-presentation')
-//   @Example<ProofExchangeRecordProps>(ProofRecordExample)
-//   public async acceptPresentation(@Request() request: Req, @Path('proofRecordId') proofRecordId: string) {
-//     try {
-//       const proof = await request.agent.modules.proofs.acceptPresentation({ proofRecordId })
-//       return proof
-//     } catch (error) {
-//       throw ErrorHandlingService.handle(error)
-//     }
-//   }
+  /**
+   * Accept a presentation as prover by sending an accept presentation message
+   * to the connection associated with the proof record.
+   *
+   * @param proofRecordId
+   * @returns ProofRecord
+   */
+  @Post('/:proofRecordId/accept-presentation')
+  @Example<DidCommProofExchangeRecordProps>(ProofRecordExample)
+  public async acceptPresentation(@Request() request: Req, @Path('proofRecordId') proofRecordId: string) {
+    try {
+      const proof = await request.agent.modules.didcomm.proofs.acceptPresentation({ proofExchangeRecordId:proofRecordId })
+      return proof
+    } catch (error) {
+      throw ErrorHandlingService.handle(error)
+    }
+  }
 
-//   /**
-//    * Return proofRecord
-//    *
-//    * @param proofRecordId
-//    * @returns ProofRecord
-//    */
-//   @Get('/:proofRecordId/form-data')
-//   @Example<ProofExchangeRecordProps>(ProofRecordExample)
-//   // TODO: Add return type
-//   public async proofFormData(@Request() request: Req, @Path('proofRecordId') proofRecordId: string) {
-//     try {
-//       const proof = await request.agent.modules.proofs.getFormatData(proofRecordId)
-//       return proof
-//     } catch (error) {
-//       throw ErrorHandlingService.handle(error)
-//     }
-//   }
-// }
+  /**
+   * Return proofRecord
+   *
+   * @param proofRecordId
+   * @returns ProofRecord
+   */
+  @Get('/:proofRecordId/form-data')
+  @Example<DidCommProofExchangeRecordProps>(ProofRecordExample)
+  // TODO: Add return type
+  public async proofFormData(@Request() request: Req, @Path('proofRecordId') proofRecordId: string) {
+    try {
+      const proof = await request.agent.modules.didcomm.proofs.getFormatData(proofRecordId)
+      return proof
+    } catch (error) {
+      throw ErrorHandlingService.handle(error)
+    }
+  }
+}

--- a/src/controllers/types.ts
+++ b/src/controllers/types.ts
@@ -259,6 +259,7 @@ export interface RequestProofOptions {
 
 // TODO: added type in protocolVersion
 export interface RequestProofProposalOptions {
+  protocolVersion: ProtocolVersion
   connectionId: string
   proofFormats: DidCommProofFormatPayload<ProofFormats, 'createProposal'>
   goalCode?: string

--- a/src/controllers/types.ts
+++ b/src/controllers/types.ts
@@ -263,7 +263,7 @@ export interface RequestProofProposalOptions {
 }
 
 export interface AcceptProofProposal {
-  proofRecordId: string
+  proofExchangeRecordId: string
   proofFormats: any
   comment?: string
   autoAcceptProof?: DidCommAutoAcceptProof

--- a/src/controllers/types.ts
+++ b/src/controllers/types.ts
@@ -2,7 +2,9 @@ import type { RecordId } from './examples'
 import type {
   AnonCredsCredentialDefinition,
   AnonCredsDidCommCredentialFormat,
+  AnonCredsDidCommProofFormat,
   LegacyIndyCredentialFormat,
+  LegacyIndyDidCommProofFormat,
   RegisterCredentialDefinitionReturnStateAction,
   RegisterCredentialDefinitionReturnStateFailed,
   RegisterCredentialDefinitionReturnStateFinished,
@@ -42,6 +44,8 @@ import type {
   DidCommMessage,
   DidCommRouting,
   DidCommAttachment,
+  DidCommProofFormatPayload,
+  DidCommDifPresentationExchangeProofFormat,
 } from '@credo-ts/didcomm'
 import type { KeyAlgorithm } from '@openwallet-foundation/askar-nodejs'
 import type { DIDDocument } from 'did-resolver'
@@ -82,6 +86,7 @@ export interface ProofRequestMessageResponse {
 
 // type CredentialFormats = [CredentialFormat]
 type CredentialFormats = [LegacyIndyCredentialFormat, AnonCredsDidCommCredentialFormat, DidCommJsonLdCredentialFormat]
+type ProofFormats = [LegacyIndyDidCommProofFormat, AnonCredsDidCommProofFormat, DidCommDifPresentationExchangeProofFormat]
 
 enum ProtocolVersion {
   v1 = 'v1',
@@ -255,7 +260,7 @@ export interface RequestProofOptions {
 // TODO: added type in protocolVersion
 export interface RequestProofProposalOptions {
   connectionId: string
-  proofFormats: any
+  proofFormats: DidCommProofFormatPayload<ProofFormats, 'createProposal'>
   goalCode?: string
   parentThreadId?: string
   autoAcceptProof?: DidCommAutoAcceptProof
@@ -264,7 +269,7 @@ export interface RequestProofProposalOptions {
 
 export interface AcceptProofProposal {
   proofExchangeRecordId: string
-  proofFormats: any
+  proofFormats: DidCommProofFormatPayload<ProofFormats, 'acceptProposal'>
   comment?: string
   autoAcceptProof?: DidCommAutoAcceptProof
   goalCode?: string

--- a/src/routes/routes.ts
+++ b/src/routes/routes.ts
@@ -37,6 +37,8 @@ import { CredentialDefinitionController } from './../controllers/anoncreds/cred-
 import { CredentialController } from './../controllers/didcomm/credentials/CredentialController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { VerifierController } from './../controllers/openid4vc/verifiers/verifier.Controller';
+// WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+import { ProofController } from './../controllers/didcomm/proofs/ProofController';
 import { expressAuthentication } from './../authentication';
 // @ts-ignore - no great way to install types from subpackage
 import { iocContainer } from './../utils/tsyringeTsoaIocContainer';
@@ -2059,6 +2061,95 @@ const models: TsoaRoute.Models = {
             "clientMetadata": {"ref":"OpenId4VcSiopVerifierClientMetadata"},
         },
         "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "DidCommProofExchangeRecord": {
+        "dataType": "refAlias",
+        "type": {"ref":"Record_string.unknown_","validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "DidCommAutoAcceptProof": {
+        "dataType": "refEnum",
+        "enums": ["always","contentApproved","never"],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "RequestProofProposalOptions": {
+        "dataType": "refObject",
+        "properties": {
+            "connectionId": {"dataType":"string","required":true},
+            "proofFormats": {"dataType":"any","required":true},
+            "goalCode": {"dataType":"string"},
+            "parentThreadId": {"dataType":"string"},
+            "autoAcceptProof": {"ref":"DidCommAutoAcceptProof"},
+            "comment": {"dataType":"string"},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "AcceptProofProposal": {
+        "dataType": "refObject",
+        "properties": {
+            "proofRecordId": {"dataType":"string","required":true},
+            "proofFormats": {"dataType":"any","required":true},
+            "comment": {"dataType":"string"},
+            "autoAcceptProof": {"ref":"DidCommAutoAcceptProof"},
+            "goalCode": {"dataType":"string"},
+            "willConfirm": {"dataType":"boolean"},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "RequestProofOptions": {
+        "dataType": "refObject",
+        "properties": {
+            "connectionId": {"dataType":"string","required":true},
+            "protocolVersion": {"dataType":"string","required":true},
+            "proofFormats": {"dataType":"any","required":true},
+            "comment": {"dataType":"string","required":true},
+            "autoAcceptProof": {"ref":"DidCommAutoAcceptProof","required":true},
+            "goalCode": {"dataType":"string"},
+            "parentThreadId": {"dataType":"string"},
+            "willConfirm": {"dataType":"boolean"},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "CreateProofRequestOobOptions": {
+        "dataType": "refObject",
+        "properties": {
+            "protocolVersion": {"dataType":"string","required":true},
+            "proofFormats": {"dataType":"any","required":true},
+            "goalCode": {"dataType":"string"},
+            "parentThreadId": {"dataType":"string"},
+            "willConfirm": {"dataType":"boolean"},
+            "autoAcceptProof": {"ref":"DidCommAutoAcceptProof"},
+            "comment": {"dataType":"string"},
+            "label": {"dataType":"string"},
+            "imageUrl": {"dataType":"string"},
+            "recipientKey": {"dataType":"string"},
+            "invitationDid": {"dataType":"string"},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "ProofFormatDataMessagePayload__40_LegacyIndyDidCommProofFormat-or-AnonCredsDidCommProofFormat-or-DidCommDifPresentationExchangeProofFormat_41_-Array.proposal_": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{},"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "ProofFormatDataMessagePayload__40_LegacyIndyDidCommProofFormat-or-AnonCredsDidCommProofFormat-or-DidCommDifPresentationExchangeProofFormat_41_-Array.request_": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{},"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "ProofFormatDataMessagePayload__40_LegacyIndyDidCommProofFormat-or-AnonCredsDidCommProofFormat-or-DidCommDifPresentationExchangeProofFormat_41_-Array.presentation_": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{},"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "GetProofFormatDataReturn__40_LegacyIndyDidCommProofFormat-or-AnonCredsDidCommProofFormat-or-DidCommDifPresentationExchangeProofFormat_41_-Array_": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"presentation":{"ref":"ProofFormatDataMessagePayload__40_LegacyIndyDidCommProofFormat-or-AnonCredsDidCommProofFormat-or-DidCommDifPresentationExchangeProofFormat_41_-Array.presentation_"},"request":{"ref":"ProofFormatDataMessagePayload__40_LegacyIndyDidCommProofFormat-or-AnonCredsDidCommProofFormat-or-DidCommDifPresentationExchangeProofFormat_41_-Array.request_"},"proposal":{"ref":"ProofFormatDataMessagePayload__40_LegacyIndyDidCommProofFormat-or-AnonCredsDidCommProofFormat-or-DidCommDifPresentationExchangeProofFormat_41_-Array.proposal_"}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 };
@@ -5237,6 +5328,340 @@ export function RegisterRoutes(app: Router) {
 
               await templateService.apiHandler({
                 methodName: 'deleteVerifier',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: undefined,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsProofController_getAllProofs: Record<string, TsoaRoute.ParameterSchema> = {
+                request: {"in":"request","name":"request","required":true,"dataType":"object"},
+                threadId: {"in":"query","name":"threadId","dataType":"string"},
+        };
+        app.get('/didcomm/proofs',
+            authenticateMiddleware([{"jwt":["tenant","dedicated"]}]),
+            ...(fetchMiddlewares<RequestHandler>(ProofController)),
+            ...(fetchMiddlewares<RequestHandler>(ProofController.prototype.getAllProofs)),
+
+            async function ProofController_getAllProofs(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsProofController_getAllProofs, request, response });
+
+                const container: IocContainer = typeof iocContainer === 'function' ? (iocContainer as IocContainerFactory)(request) : iocContainer;
+
+                const controller: any = await container.get<ProofController>(ProofController);
+                if (typeof controller['setStatus'] === 'function') {
+                controller.setStatus(undefined);
+                }
+
+              await templateService.apiHandler({
+                methodName: 'getAllProofs',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: undefined,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsProofController_getProofById: Record<string, TsoaRoute.ParameterSchema> = {
+                request: {"in":"request","name":"request","required":true,"dataType":"object"},
+                proofRecordId: {"in":"path","name":"proofRecordId","required":true,"ref":"RecordId"},
+        };
+        app.get('/didcomm/proofs/:proofRecordId',
+            authenticateMiddleware([{"jwt":["tenant","dedicated"]}]),
+            ...(fetchMiddlewares<RequestHandler>(ProofController)),
+            ...(fetchMiddlewares<RequestHandler>(ProofController.prototype.getProofById)),
+
+            async function ProofController_getProofById(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsProofController_getProofById, request, response });
+
+                const container: IocContainer = typeof iocContainer === 'function' ? (iocContainer as IocContainerFactory)(request) : iocContainer;
+
+                const controller: any = await container.get<ProofController>(ProofController);
+                if (typeof controller['setStatus'] === 'function') {
+                controller.setStatus(undefined);
+                }
+
+              await templateService.apiHandler({
+                methodName: 'getProofById',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: undefined,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsProofController_proposeProof: Record<string, TsoaRoute.ParameterSchema> = {
+                request: {"in":"request","name":"request","required":true,"dataType":"object"},
+                requestProofProposalOptions: {"in":"body","name":"requestProofProposalOptions","required":true,"ref":"RequestProofProposalOptions"},
+        };
+        app.post('/didcomm/proofs/propose-proof',
+            authenticateMiddleware([{"jwt":["tenant","dedicated"]}]),
+            ...(fetchMiddlewares<RequestHandler>(ProofController)),
+            ...(fetchMiddlewares<RequestHandler>(ProofController.prototype.proposeProof)),
+
+            async function ProofController_proposeProof(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsProofController_proposeProof, request, response });
+
+                const container: IocContainer = typeof iocContainer === 'function' ? (iocContainer as IocContainerFactory)(request) : iocContainer;
+
+                const controller: any = await container.get<ProofController>(ProofController);
+                if (typeof controller['setStatus'] === 'function') {
+                controller.setStatus(undefined);
+                }
+
+              await templateService.apiHandler({
+                methodName: 'proposeProof',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: undefined,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsProofController_acceptProposal: Record<string, TsoaRoute.ParameterSchema> = {
+                request: {"in":"request","name":"request","required":true,"dataType":"object"},
+                acceptProposal: {"in":"body","name":"acceptProposal","required":true,"ref":"AcceptProofProposal"},
+        };
+        app.post('/didcomm/proofs/:proofRecordId/accept-proposal',
+            authenticateMiddleware([{"jwt":["tenant","dedicated"]}]),
+            ...(fetchMiddlewares<RequestHandler>(ProofController)),
+            ...(fetchMiddlewares<RequestHandler>(ProofController.prototype.acceptProposal)),
+
+            async function ProofController_acceptProposal(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsProofController_acceptProposal, request, response });
+
+                const container: IocContainer = typeof iocContainer === 'function' ? (iocContainer as IocContainerFactory)(request) : iocContainer;
+
+                const controller: any = await container.get<ProofController>(ProofController);
+                if (typeof controller['setStatus'] === 'function') {
+                controller.setStatus(undefined);
+                }
+
+              await templateService.apiHandler({
+                methodName: 'acceptProposal',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: undefined,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsProofController_requestProof: Record<string, TsoaRoute.ParameterSchema> = {
+                request: {"in":"request","name":"request","required":true,"dataType":"object"},
+                requestProofOptions: {"in":"body","name":"requestProofOptions","required":true,"ref":"RequestProofOptions"},
+        };
+        app.post('/didcomm/proofs/request-proof',
+            authenticateMiddleware([{"jwt":["tenant","dedicated"]}]),
+            ...(fetchMiddlewares<RequestHandler>(ProofController)),
+            ...(fetchMiddlewares<RequestHandler>(ProofController.prototype.requestProof)),
+
+            async function ProofController_requestProof(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsProofController_requestProof, request, response });
+
+                const container: IocContainer = typeof iocContainer === 'function' ? (iocContainer as IocContainerFactory)(request) : iocContainer;
+
+                const controller: any = await container.get<ProofController>(ProofController);
+                if (typeof controller['setStatus'] === 'function') {
+                controller.setStatus(undefined);
+                }
+
+              await templateService.apiHandler({
+                methodName: 'requestProof',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: undefined,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsProofController_createRequest: Record<string, TsoaRoute.ParameterSchema> = {
+                request: {"in":"request","name":"request","required":true,"dataType":"object"},
+                createRequestOptions: {"in":"body","name":"createRequestOptions","required":true,"ref":"CreateProofRequestOobOptions"},
+        };
+        app.post('/didcomm/proofs/create-request-oob',
+            authenticateMiddleware([{"jwt":["tenant","dedicated"]}]),
+            ...(fetchMiddlewares<RequestHandler>(ProofController)),
+            ...(fetchMiddlewares<RequestHandler>(ProofController.prototype.createRequest)),
+
+            async function ProofController_createRequest(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsProofController_createRequest, request, response });
+
+                const container: IocContainer = typeof iocContainer === 'function' ? (iocContainer as IocContainerFactory)(request) : iocContainer;
+
+                const controller: any = await container.get<ProofController>(ProofController);
+                if (typeof controller['setStatus'] === 'function') {
+                controller.setStatus(undefined);
+                }
+
+              await templateService.apiHandler({
+                methodName: 'createRequest',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: undefined,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsProofController_acceptRequest: Record<string, TsoaRoute.ParameterSchema> = {
+                request: {"in":"request","name":"request","required":true,"dataType":"object"},
+                proofRecordId: {"in":"path","name":"proofRecordId","required":true,"dataType":"string"},
+                body: {"in":"body","name":"body","required":true,"dataType":"nestedObjectLiteral","nestedProperties":{"comment":{"dataType":"string"},"filterByNonRevocationRequirements":{"dataType":"boolean"},"filterByPresentationPreview":{"dataType":"boolean"}}},
+        };
+        app.post('/didcomm/proofs/:proofRecordId/accept-request',
+            authenticateMiddleware([{"jwt":["tenant","dedicated"]}]),
+            ...(fetchMiddlewares<RequestHandler>(ProofController)),
+            ...(fetchMiddlewares<RequestHandler>(ProofController.prototype.acceptRequest)),
+
+            async function ProofController_acceptRequest(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsProofController_acceptRequest, request, response });
+
+                const container: IocContainer = typeof iocContainer === 'function' ? (iocContainer as IocContainerFactory)(request) : iocContainer;
+
+                const controller: any = await container.get<ProofController>(ProofController);
+                if (typeof controller['setStatus'] === 'function') {
+                controller.setStatus(undefined);
+                }
+
+              await templateService.apiHandler({
+                methodName: 'acceptRequest',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: undefined,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsProofController_acceptPresentation: Record<string, TsoaRoute.ParameterSchema> = {
+                request: {"in":"request","name":"request","required":true,"dataType":"object"},
+                proofRecordId: {"in":"path","name":"proofRecordId","required":true,"dataType":"string"},
+        };
+        app.post('/didcomm/proofs/:proofRecordId/accept-presentation',
+            authenticateMiddleware([{"jwt":["tenant","dedicated"]}]),
+            ...(fetchMiddlewares<RequestHandler>(ProofController)),
+            ...(fetchMiddlewares<RequestHandler>(ProofController.prototype.acceptPresentation)),
+
+            async function ProofController_acceptPresentation(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsProofController_acceptPresentation, request, response });
+
+                const container: IocContainer = typeof iocContainer === 'function' ? (iocContainer as IocContainerFactory)(request) : iocContainer;
+
+                const controller: any = await container.get<ProofController>(ProofController);
+                if (typeof controller['setStatus'] === 'function') {
+                controller.setStatus(undefined);
+                }
+
+              await templateService.apiHandler({
+                methodName: 'acceptPresentation',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: undefined,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsProofController_proofFormData: Record<string, TsoaRoute.ParameterSchema> = {
+                request: {"in":"request","name":"request","required":true,"dataType":"object"},
+                proofRecordId: {"in":"path","name":"proofRecordId","required":true,"dataType":"string"},
+        };
+        app.get('/didcomm/proofs/:proofRecordId/form-data',
+            authenticateMiddleware([{"jwt":["tenant","dedicated"]}]),
+            ...(fetchMiddlewares<RequestHandler>(ProofController)),
+            ...(fetchMiddlewares<RequestHandler>(ProofController.prototype.proofFormData)),
+
+            async function ProofController_proofFormData(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsProofController_proofFormData, request, response });
+
+                const container: IocContainer = typeof iocContainer === 'function' ? (iocContainer as IocContainerFactory)(request) : iocContainer;
+
+                const controller: any = await container.get<ProofController>(ProofController);
+                if (typeof controller['setStatus'] === 'function') {
+                controller.setStatus(undefined);
+                }
+
+              await templateService.apiHandler({
+                methodName: 'proofFormData',
                 controller,
                 response,
                 next,

--- a/src/routes/routes.ts
+++ b/src/routes/routes.ts
@@ -36,9 +36,9 @@ import { CredentialDefinitionController } from './../controllers/anoncreds/cred-
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { CredentialController } from './../controllers/didcomm/credentials/CredentialController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-import { VerifierController } from './../controllers/openid4vc/verifiers/verifier.Controller';
-// WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { ProofController } from './../controllers/didcomm/proofs/ProofController';
+// WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+import { VerifierController } from './../controllers/openid4vc/verifiers/verifier.Controller';
 import { expressAuthentication } from './../authentication';
 // @ts-ignore - no great way to install types from subpackage
 import { iocContainer } from './../utils/tsyringeTsoaIocContainer';
@@ -2032,40 +2032,143 @@ const models: TsoaRoute.Models = {
         "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"credential":{"ref":"CredentialFormatDataMessagePayload__40_LegacyIndyCredentialFormat-or-DidCommJsonLdCredentialFormat-or-AnonCredsDidCommCredentialFormat_41_-Array.credential_"},"request":{"ref":"CredentialFormatDataMessagePayload__40_LegacyIndyCredentialFormat-or-DidCommJsonLdCredentialFormat-or-AnonCredsDidCommCredentialFormat_41_-Array.request_"},"offerAttributes":{"dataType":"array","array":{"dataType":"refObject","ref":"DidCommCredentialPreviewAttributeOptions"}},"offer":{"ref":"CredentialFormatDataMessagePayload__40_LegacyIndyCredentialFormat-or-DidCommJsonLdCredentialFormat-or-AnonCredsDidCommCredentialFormat_41_-Array.offer_"},"proposal":{"ref":"CredentialFormatDataMessagePayload__40_LegacyIndyCredentialFormat-or-DidCommJsonLdCredentialFormat-or-AnonCredsDidCommCredentialFormat_41_-Array.proposal_"},"proposalAttributes":{"dataType":"array","array":{"dataType":"refObject","ref":"DidCommCredentialPreviewAttributeOptions"}}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "OpenId4VcVerifierRecord": {
-        "dataType": "refAlias",
-        "type": {"ref":"Record_string.unknown_","validators":{}},
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "OpenId4VcSiopVerifierClientMetadata": {
-        "dataType": "refObject",
-        "properties": {
-            "client_name": {"dataType":"string"},
-            "logo_uri": {"dataType":"string"},
-        },
-        "additionalProperties": false,
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "OpenId4VcSiopCreateVerifierOptions": {
-        "dataType": "refObject",
-        "properties": {
-            "verifierId": {"dataType":"string"},
-            "clientMetadata": {"ref":"OpenId4VcSiopVerifierClientMetadata"},
-        },
-        "additionalProperties": false,
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "OpenId4VcUpdateVerifierRecordOptions": {
-        "dataType": "refObject",
-        "properties": {
-            "clientMetadata": {"ref":"OpenId4VcSiopVerifierClientMetadata"},
-        },
-        "additionalProperties": false,
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "DidCommProofExchangeRecord": {
         "dataType": "refAlias",
         "type": {"ref":"Record_string.unknown_","validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "AnonCredsPresentationPreviewAttribute": {
+        "dataType": "refObject",
+        "properties": {
+            "name": {"dataType":"string","required":true},
+            "credentialDefinitionId": {"dataType":"string"},
+            "mimeType": {"dataType":"string"},
+            "value": {"dataType":"string"},
+            "referent": {"dataType":"string"},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "AnonCredsPredicateType": {
+        "dataType": "refAlias",
+        "type": {"dataType":"union","subSchemas":[{"dataType":"enum","enums":[">="]},{"dataType":"enum","enums":[">"]},{"dataType":"enum","enums":["<="]},{"dataType":"enum","enums":["<"]}],"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "AnonCredsPresentationPreviewPredicate": {
+        "dataType": "refObject",
+        "properties": {
+            "name": {"dataType":"string","required":true},
+            "credentialDefinitionId": {"dataType":"string","required":true},
+            "predicate": {"ref":"AnonCredsPredicateType","required":true},
+            "threshold": {"dataType":"double","required":true},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "AnonCredsNonRevokedInterval": {
+        "dataType": "refObject",
+        "properties": {
+            "from": {"dataType":"double"},
+            "to": {"dataType":"double"},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "AnonCredsProposeProofFormat": {
+        "dataType": "refObject",
+        "properties": {
+            "name": {"dataType":"string"},
+            "version": {"dataType":"string"},
+            "attributes": {"dataType":"array","array":{"dataType":"refObject","ref":"AnonCredsPresentationPreviewAttribute"}},
+            "predicates": {"dataType":"array","array":{"dataType":"refObject","ref":"AnonCredsPresentationPreviewPredicate"}},
+            "nonRevokedInterval": {"ref":"AnonCredsNonRevokedInterval"},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "Schema": {
+        "dataType": "refObject",
+        "properties": {
+            "uri": {"dataType":"string","required":true},
+            "required": {"dataType":"boolean"},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "FilterV1": {
+        "dataType": "refObject",
+        "properties": {
+            "const": {"ref":"OneOfNumberStringBoolean"},
+            "enum": {"dataType":"array","array":{"dataType":"refAlias","ref":"OneOfNumberStringBoolean"}},
+            "exclusiveMinimum": {"ref":"OneOfNumberString"},
+            "exclusiveMaximum": {"ref":"OneOfNumberString"},
+            "format": {"dataType":"string"},
+            "minLength": {"dataType":"double"},
+            "maxLength": {"dataType":"double"},
+            "minimum": {"ref":"OneOfNumberString"},
+            "maximum": {"ref":"OneOfNumberString"},
+            "not": {"dataType":"object"},
+            "pattern": {"dataType":"string"},
+            "type": {"dataType":"string"},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "FieldV1": {
+        "dataType": "refObject",
+        "properties": {
+            "id": {"dataType":"string"},
+            "path": {"dataType":"array","array":{"dataType":"string"},"required":true},
+            "purpose": {"dataType":"string"},
+            "filter": {"ref":"FilterV1"},
+            "predicate": {"ref":"Optionality"},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "ConstraintsV1": {
+        "dataType": "refObject",
+        "properties": {
+            "limit_disclosure": {"ref":"Optionality"},
+            "statuses": {"ref":"Statuses"},
+            "fields": {"dataType":"array","array":{"dataType":"refObject","ref":"FieldV1"}},
+            "subject_is_issuer": {"ref":"Optionality"},
+            "is_holder": {"dataType":"array","array":{"dataType":"refObject","ref":"HolderSubject"}},
+            "same_subject": {"dataType":"array","array":{"dataType":"refObject","ref":"HolderSubject"}},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "InputDescriptorV1": {
+        "dataType": "refObject",
+        "properties": {
+            "id": {"dataType":"string","required":true},
+            "name": {"dataType":"string"},
+            "purpose": {"dataType":"string"},
+            "group": {"dataType":"array","array":{"dataType":"string"}},
+            "schema": {"dataType":"array","array":{"dataType":"refObject","ref":"Schema"},"required":true},
+            "issuance": {"dataType":"array","array":{"dataType":"refObject","ref":"Issuance"}},
+            "constraints": {"ref":"ConstraintsV1"},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "PresentationDefinitionV1": {
+        "dataType": "refObject",
+        "properties": {
+            "id": {"dataType":"string","required":true},
+            "name": {"dataType":"string"},
+            "purpose": {"dataType":"string"},
+            "format": {"ref":"Format"},
+            "submission_requirements": {"dataType":"array","array":{"dataType":"refObject","ref":"SubmissionRequirement"}},
+            "input_descriptors": {"dataType":"array","array":{"dataType":"refObject","ref":"InputDescriptorV1"},"required":true},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "DidCommProofFormatPayload_ProofFormats.createProposal_": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"indy":{"ref":"AnonCredsProposeProofFormat"},"anoncreds":{"ref":"AnonCredsProposeProofFormat"},"presentationExchange":{"dataType":"nestedObjectLiteral","nestedProperties":{"presentationDefinition":{"ref":"PresentationDefinitionV1","required":true}}}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "DidCommAutoAcceptProof": {
@@ -2077,7 +2180,7 @@ const models: TsoaRoute.Models = {
         "dataType": "refObject",
         "properties": {
             "connectionId": {"dataType":"string","required":true},
-            "proofFormats": {"dataType":"any","required":true},
+            "proofFormats": {"ref":"DidCommProofFormatPayload_ProofFormats.createProposal_","required":true},
             "goalCode": {"dataType":"string"},
             "parentThreadId": {"dataType":"string"},
             "autoAcceptProof": {"ref":"DidCommAutoAcceptProof"},
@@ -2086,11 +2189,16 @@ const models: TsoaRoute.Models = {
         "additionalProperties": false,
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "DidCommProofFormatPayload_ProofFormats.acceptProposal_": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"indy":{"dataType":"nestedObjectLiteral","nestedProperties":{"version":{"dataType":"string"},"name":{"dataType":"string"}}},"anoncreds":{"dataType":"nestedObjectLiteral","nestedProperties":{"version":{"dataType":"string"},"name":{"dataType":"string"}}},"presentationExchange":{"dataType":"nestedObjectLiteral","nestedProperties":{"options":{"dataType":"nestedObjectLiteral","nestedProperties":{"domain":{"dataType":"string"},"challenge":{"dataType":"string"}}}}}},"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "AcceptProofProposal": {
         "dataType": "refObject",
         "properties": {
-            "proofRecordId": {"dataType":"string","required":true},
-            "proofFormats": {"dataType":"any","required":true},
+            "proofExchangeRecordId": {"dataType":"string","required":true},
+            "proofFormats": {"ref":"DidCommProofFormatPayload_ProofFormats.acceptProposal_","required":true},
             "comment": {"dataType":"string"},
             "autoAcceptProof": {"ref":"DidCommAutoAcceptProof"},
             "goalCode": {"dataType":"string"},
@@ -2150,6 +2258,37 @@ const models: TsoaRoute.Models = {
     "GetProofFormatDataReturn__40_LegacyIndyDidCommProofFormat-or-AnonCredsDidCommProofFormat-or-DidCommDifPresentationExchangeProofFormat_41_-Array_": {
         "dataType": "refAlias",
         "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"presentation":{"ref":"ProofFormatDataMessagePayload__40_LegacyIndyDidCommProofFormat-or-AnonCredsDidCommProofFormat-or-DidCommDifPresentationExchangeProofFormat_41_-Array.presentation_"},"request":{"ref":"ProofFormatDataMessagePayload__40_LegacyIndyDidCommProofFormat-or-AnonCredsDidCommProofFormat-or-DidCommDifPresentationExchangeProofFormat_41_-Array.request_"},"proposal":{"ref":"ProofFormatDataMessagePayload__40_LegacyIndyDidCommProofFormat-or-AnonCredsDidCommProofFormat-or-DidCommDifPresentationExchangeProofFormat_41_-Array.proposal_"}},"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "OpenId4VcVerifierRecord": {
+        "dataType": "refAlias",
+        "type": {"ref":"Record_string.unknown_","validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "OpenId4VcSiopVerifierClientMetadata": {
+        "dataType": "refObject",
+        "properties": {
+            "client_name": {"dataType":"string"},
+            "logo_uri": {"dataType":"string"},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "OpenId4VcSiopCreateVerifierOptions": {
+        "dataType": "refObject",
+        "properties": {
+            "verifierId": {"dataType":"string"},
+            "clientMetadata": {"ref":"OpenId4VcSiopVerifierClientMetadata"},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "OpenId4VcUpdateVerifierRecordOptions": {
+        "dataType": "refObject",
+        "properties": {
+            "clientMetadata": {"ref":"OpenId4VcSiopVerifierClientMetadata"},
+        },
+        "additionalProperties": false,
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 };
@@ -5153,192 +5292,6 @@ export function RegisterRoutes(app: Router) {
             }
         });
         // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        const argsVerifierController_createVerifier: Record<string, TsoaRoute.ParameterSchema> = {
-                request: {"in":"request","name":"request","required":true,"dataType":"object"},
-                options: {"in":"body","name":"options","required":true,"ref":"OpenId4VcSiopCreateVerifierOptions"},
-        };
-        app.post('/openid4vc/verifier',
-            authenticateMiddleware([{"jwt":["tenant","dedicated"]}]),
-            ...(fetchMiddlewares<RequestHandler>(VerifierController)),
-            ...(fetchMiddlewares<RequestHandler>(VerifierController.prototype.createVerifier)),
-
-            async function VerifierController_createVerifier(request: ExRequest, response: ExResponse, next: any) {
-
-            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-
-            let validatedArgs: any[] = [];
-            try {
-                validatedArgs = templateService.getValidatedArgs({ args: argsVerifierController_createVerifier, request, response });
-
-                const container: IocContainer = typeof iocContainer === 'function' ? (iocContainer as IocContainerFactory)(request) : iocContainer;
-
-                const controller: any = await container.get<VerifierController>(VerifierController);
-                if (typeof controller['setStatus'] === 'function') {
-                controller.setStatus(undefined);
-                }
-
-              await templateService.apiHandler({
-                methodName: 'createVerifier',
-                controller,
-                response,
-                next,
-                validatedArgs,
-                successStatus: undefined,
-              });
-            } catch (err) {
-                return next(err);
-            }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        const argsVerifierController_updateVerifierMetadata: Record<string, TsoaRoute.ParameterSchema> = {
-                request: {"in":"request","name":"request","required":true,"dataType":"object"},
-                publicVerifierId: {"in":"path","name":"publicVerifierId","required":true,"dataType":"string"},
-                verifierRecordOptions: {"in":"body","name":"verifierRecordOptions","required":true,"ref":"OpenId4VcUpdateVerifierRecordOptions"},
-        };
-        app.put('/openid4vc/verifier/:publicVerifierId',
-            authenticateMiddleware([{"jwt":["tenant","dedicated"]}]),
-            ...(fetchMiddlewares<RequestHandler>(VerifierController)),
-            ...(fetchMiddlewares<RequestHandler>(VerifierController.prototype.updateVerifierMetadata)),
-
-            async function VerifierController_updateVerifierMetadata(request: ExRequest, response: ExResponse, next: any) {
-
-            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-
-            let validatedArgs: any[] = [];
-            try {
-                validatedArgs = templateService.getValidatedArgs({ args: argsVerifierController_updateVerifierMetadata, request, response });
-
-                const container: IocContainer = typeof iocContainer === 'function' ? (iocContainer as IocContainerFactory)(request) : iocContainer;
-
-                const controller: any = await container.get<VerifierController>(VerifierController);
-                if (typeof controller['setStatus'] === 'function') {
-                controller.setStatus(undefined);
-                }
-
-              await templateService.apiHandler({
-                methodName: 'updateVerifierMetadata',
-                controller,
-                response,
-                next,
-                validatedArgs,
-                successStatus: undefined,
-              });
-            } catch (err) {
-                return next(err);
-            }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        const argsVerifierController_getVerifiersByQuery: Record<string, TsoaRoute.ParameterSchema> = {
-                request: {"in":"request","name":"request","required":true,"dataType":"object"},
-                publicVerifierId: {"in":"query","name":"publicVerifierId","dataType":"string"},
-        };
-        app.get('/openid4vc/verifier',
-            authenticateMiddleware([{"jwt":["tenant","dedicated"]}]),
-            ...(fetchMiddlewares<RequestHandler>(VerifierController)),
-            ...(fetchMiddlewares<RequestHandler>(VerifierController.prototype.getVerifiersByQuery)),
-
-            async function VerifierController_getVerifiersByQuery(request: ExRequest, response: ExResponse, next: any) {
-
-            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-
-            let validatedArgs: any[] = [];
-            try {
-                validatedArgs = templateService.getValidatedArgs({ args: argsVerifierController_getVerifiersByQuery, request, response });
-
-                const container: IocContainer = typeof iocContainer === 'function' ? (iocContainer as IocContainerFactory)(request) : iocContainer;
-
-                const controller: any = await container.get<VerifierController>(VerifierController);
-                if (typeof controller['setStatus'] === 'function') {
-                controller.setStatus(undefined);
-                }
-
-              await templateService.apiHandler({
-                methodName: 'getVerifiersByQuery',
-                controller,
-                response,
-                next,
-                validatedArgs,
-                successStatus: undefined,
-              });
-            } catch (err) {
-                return next(err);
-            }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        const argsVerifierController_getVerifier: Record<string, TsoaRoute.ParameterSchema> = {
-                request: {"in":"request","name":"request","required":true,"dataType":"object"},
-                publicVerifierId: {"in":"path","name":"publicVerifierId","required":true,"dataType":"string"},
-        };
-        app.get('/openid4vc/verifier/:publicVerifierId',
-            authenticateMiddleware([{"jwt":["tenant","dedicated"]}]),
-            ...(fetchMiddlewares<RequestHandler>(VerifierController)),
-            ...(fetchMiddlewares<RequestHandler>(VerifierController.prototype.getVerifier)),
-
-            async function VerifierController_getVerifier(request: ExRequest, response: ExResponse, next: any) {
-
-            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-
-            let validatedArgs: any[] = [];
-            try {
-                validatedArgs = templateService.getValidatedArgs({ args: argsVerifierController_getVerifier, request, response });
-
-                const container: IocContainer = typeof iocContainer === 'function' ? (iocContainer as IocContainerFactory)(request) : iocContainer;
-
-                const controller: any = await container.get<VerifierController>(VerifierController);
-                if (typeof controller['setStatus'] === 'function') {
-                controller.setStatus(undefined);
-                }
-
-              await templateService.apiHandler({
-                methodName: 'getVerifier',
-                controller,
-                response,
-                next,
-                validatedArgs,
-                successStatus: undefined,
-              });
-            } catch (err) {
-                return next(err);
-            }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        const argsVerifierController_deleteVerifier: Record<string, TsoaRoute.ParameterSchema> = {
-                request: {"in":"request","name":"request","required":true,"dataType":"object"},
-                verifierId: {"in":"path","name":"verifierId","required":true,"dataType":"string"},
-        };
-        app.delete('/openid4vc/verifier/:verifierId',
-            authenticateMiddleware([{"jwt":["tenant","dedicated"]}]),
-            ...(fetchMiddlewares<RequestHandler>(VerifierController)),
-            ...(fetchMiddlewares<RequestHandler>(VerifierController.prototype.deleteVerifier)),
-
-            async function VerifierController_deleteVerifier(request: ExRequest, response: ExResponse, next: any) {
-
-            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-
-            let validatedArgs: any[] = [];
-            try {
-                validatedArgs = templateService.getValidatedArgs({ args: argsVerifierController_deleteVerifier, request, response });
-
-                const container: IocContainer = typeof iocContainer === 'function' ? (iocContainer as IocContainerFactory)(request) : iocContainer;
-
-                const controller: any = await container.get<VerifierController>(VerifierController);
-                if (typeof controller['setStatus'] === 'function') {
-                controller.setStatus(undefined);
-                }
-
-              await templateService.apiHandler({
-                methodName: 'deleteVerifier',
-                controller,
-                response,
-                next,
-                validatedArgs,
-                successStatus: undefined,
-              });
-            } catch (err) {
-                return next(err);
-            }
-        });
-        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
         const argsProofController_getAllProofs: Record<string, TsoaRoute.ParameterSchema> = {
                 request: {"in":"request","name":"request","required":true,"dataType":"object"},
                 threadId: {"in":"query","name":"threadId","dataType":"string"},
@@ -5662,6 +5615,192 @@ export function RegisterRoutes(app: Router) {
 
               await templateService.apiHandler({
                 methodName: 'proofFormData',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: undefined,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsVerifierController_createVerifier: Record<string, TsoaRoute.ParameterSchema> = {
+                request: {"in":"request","name":"request","required":true,"dataType":"object"},
+                options: {"in":"body","name":"options","required":true,"ref":"OpenId4VcSiopCreateVerifierOptions"},
+        };
+        app.post('/openid4vc/verifier',
+            authenticateMiddleware([{"jwt":["tenant","dedicated"]}]),
+            ...(fetchMiddlewares<RequestHandler>(VerifierController)),
+            ...(fetchMiddlewares<RequestHandler>(VerifierController.prototype.createVerifier)),
+
+            async function VerifierController_createVerifier(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsVerifierController_createVerifier, request, response });
+
+                const container: IocContainer = typeof iocContainer === 'function' ? (iocContainer as IocContainerFactory)(request) : iocContainer;
+
+                const controller: any = await container.get<VerifierController>(VerifierController);
+                if (typeof controller['setStatus'] === 'function') {
+                controller.setStatus(undefined);
+                }
+
+              await templateService.apiHandler({
+                methodName: 'createVerifier',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: undefined,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsVerifierController_updateVerifierMetadata: Record<string, TsoaRoute.ParameterSchema> = {
+                request: {"in":"request","name":"request","required":true,"dataType":"object"},
+                publicVerifierId: {"in":"path","name":"publicVerifierId","required":true,"dataType":"string"},
+                verifierRecordOptions: {"in":"body","name":"verifierRecordOptions","required":true,"ref":"OpenId4VcUpdateVerifierRecordOptions"},
+        };
+        app.put('/openid4vc/verifier/:publicVerifierId',
+            authenticateMiddleware([{"jwt":["tenant","dedicated"]}]),
+            ...(fetchMiddlewares<RequestHandler>(VerifierController)),
+            ...(fetchMiddlewares<RequestHandler>(VerifierController.prototype.updateVerifierMetadata)),
+
+            async function VerifierController_updateVerifierMetadata(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsVerifierController_updateVerifierMetadata, request, response });
+
+                const container: IocContainer = typeof iocContainer === 'function' ? (iocContainer as IocContainerFactory)(request) : iocContainer;
+
+                const controller: any = await container.get<VerifierController>(VerifierController);
+                if (typeof controller['setStatus'] === 'function') {
+                controller.setStatus(undefined);
+                }
+
+              await templateService.apiHandler({
+                methodName: 'updateVerifierMetadata',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: undefined,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsVerifierController_getVerifiersByQuery: Record<string, TsoaRoute.ParameterSchema> = {
+                request: {"in":"request","name":"request","required":true,"dataType":"object"},
+                publicVerifierId: {"in":"query","name":"publicVerifierId","dataType":"string"},
+        };
+        app.get('/openid4vc/verifier',
+            authenticateMiddleware([{"jwt":["tenant","dedicated"]}]),
+            ...(fetchMiddlewares<RequestHandler>(VerifierController)),
+            ...(fetchMiddlewares<RequestHandler>(VerifierController.prototype.getVerifiersByQuery)),
+
+            async function VerifierController_getVerifiersByQuery(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsVerifierController_getVerifiersByQuery, request, response });
+
+                const container: IocContainer = typeof iocContainer === 'function' ? (iocContainer as IocContainerFactory)(request) : iocContainer;
+
+                const controller: any = await container.get<VerifierController>(VerifierController);
+                if (typeof controller['setStatus'] === 'function') {
+                controller.setStatus(undefined);
+                }
+
+              await templateService.apiHandler({
+                methodName: 'getVerifiersByQuery',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: undefined,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsVerifierController_getVerifier: Record<string, TsoaRoute.ParameterSchema> = {
+                request: {"in":"request","name":"request","required":true,"dataType":"object"},
+                publicVerifierId: {"in":"path","name":"publicVerifierId","required":true,"dataType":"string"},
+        };
+        app.get('/openid4vc/verifier/:publicVerifierId',
+            authenticateMiddleware([{"jwt":["tenant","dedicated"]}]),
+            ...(fetchMiddlewares<RequestHandler>(VerifierController)),
+            ...(fetchMiddlewares<RequestHandler>(VerifierController.prototype.getVerifier)),
+
+            async function VerifierController_getVerifier(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsVerifierController_getVerifier, request, response });
+
+                const container: IocContainer = typeof iocContainer === 'function' ? (iocContainer as IocContainerFactory)(request) : iocContainer;
+
+                const controller: any = await container.get<VerifierController>(VerifierController);
+                if (typeof controller['setStatus'] === 'function') {
+                controller.setStatus(undefined);
+                }
+
+              await templateService.apiHandler({
+                methodName: 'getVerifier',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: undefined,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsVerifierController_deleteVerifier: Record<string, TsoaRoute.ParameterSchema> = {
+                request: {"in":"request","name":"request","required":true,"dataType":"object"},
+                verifierId: {"in":"path","name":"verifierId","required":true,"dataType":"string"},
+        };
+        app.delete('/openid4vc/verifier/:verifierId',
+            authenticateMiddleware([{"jwt":["tenant","dedicated"]}]),
+            ...(fetchMiddlewares<RequestHandler>(VerifierController)),
+            ...(fetchMiddlewares<RequestHandler>(VerifierController.prototype.deleteVerifier)),
+
+            async function VerifierController_deleteVerifier(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsVerifierController_deleteVerifier, request, response });
+
+                const container: IocContainer = typeof iocContainer === 'function' ? (iocContainer as IocContainerFactory)(request) : iocContainer;
+
+                const controller: any = await container.get<VerifierController>(VerifierController);
+                if (typeof controller['setStatus'] === 'function') {
+                controller.setStatus(undefined);
+                }
+
+              await templateService.apiHandler({
+                methodName: 'deleteVerifier',
                 controller,
                 response,
                 next,

--- a/src/routes/routes.ts
+++ b/src/routes/routes.ts
@@ -2179,6 +2179,7 @@ const models: TsoaRoute.Models = {
     "RequestProofProposalOptions": {
         "dataType": "refObject",
         "properties": {
+            "protocolVersion": {"ref":"ProtocolVersion","required":true},
             "connectionId": {"dataType":"string","required":true},
             "proofFormats": {"ref":"DidCommProofFormatPayload_ProofFormats.createProposal_","required":true},
             "goalCode": {"dataType":"string"},
@@ -5407,7 +5408,7 @@ export function RegisterRoutes(app: Router) {
                 request: {"in":"request","name":"request","required":true,"dataType":"object"},
                 acceptProposal: {"in":"body","name":"acceptProposal","required":true,"ref":"AcceptProofProposal"},
         };
-        app.post('/didcomm/proofs/:proofRecordId/accept-proposal',
+        app.post('/didcomm/proofs/accept-proposal',
             authenticateMiddleware([{"jwt":["tenant","dedicated"]}]),
             ...(fetchMiddlewares<RequestHandler>(ProofController)),
             ...(fetchMiddlewares<RequestHandler>(ProofController.prototype.acceptProposal)),

--- a/src/routes/swagger.json
+++ b/src/routes/swagger.json
@@ -4581,45 +4581,328 @@
 				"type": "object",
 				"description": "Get format data return value. Each key holds a mapping of credential format key to format data."
 			},
-			"OpenId4VcVerifierRecord": {
-				"$ref": "#/components/schemas/Record_string.unknown_",
-				"description": "For OID4VC you need to expos metadata files. Each issuer needs to host this metadata. This is not the case for DIDComm where we can just have one /didcomm endpoint.\nSo we create a record per openid issuer/verifier that you want, and each tenant can create multiple issuers/verifiers which have different endpoints\nand metadata files"
-			},
-			"OpenId4VcSiopVerifierClientMetadata": {
-				"properties": {
-					"client_name": {
-						"type": "string"
-					},
-					"logo_uri": {
-						"type": "string"
-					}
-				},
-				"type": "object",
-				"additionalProperties": false
-			},
-			"OpenId4VcSiopCreateVerifierOptions": {
-				"properties": {
-					"verifierId": {
-						"type": "string"
-					},
-					"clientMetadata": {
-						"$ref": "#/components/schemas/OpenId4VcSiopVerifierClientMetadata"
-					}
-				},
-				"type": "object",
-				"additionalProperties": false
-			},
-			"OpenId4VcUpdateVerifierRecordOptions": {
-				"properties": {
-					"clientMetadata": {
-						"$ref": "#/components/schemas/OpenId4VcSiopVerifierClientMetadata"
-					}
-				},
-				"type": "object",
-				"additionalProperties": false
-			},
 			"DidCommProofExchangeRecord": {
 				"$ref": "#/components/schemas/Record_string.unknown_"
+			},
+			"AnonCredsPresentationPreviewAttribute": {
+				"properties": {
+					"name": {
+						"type": "string"
+					},
+					"credentialDefinitionId": {
+						"type": "string"
+					},
+					"mimeType": {
+						"type": "string"
+					},
+					"value": {
+						"type": "string"
+					},
+					"referent": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"name"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"AnonCredsPredicateType": {
+				"type": "string",
+				"enum": [
+					">=",
+					">",
+					"<=",
+					"<"
+				]
+			},
+			"AnonCredsPresentationPreviewPredicate": {
+				"properties": {
+					"name": {
+						"type": "string"
+					},
+					"credentialDefinitionId": {
+						"type": "string"
+					},
+					"predicate": {
+						"$ref": "#/components/schemas/AnonCredsPredicateType"
+					},
+					"threshold": {
+						"type": "number",
+						"format": "double"
+					}
+				},
+				"required": [
+					"name",
+					"credentialDefinitionId",
+					"predicate",
+					"threshold"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"AnonCredsNonRevokedInterval": {
+				"properties": {
+					"from": {
+						"type": "number",
+						"format": "double"
+					},
+					"to": {
+						"type": "number",
+						"format": "double"
+					}
+				},
+				"type": "object",
+				"additionalProperties": false
+			},
+			"AnonCredsProposeProofFormat": {
+				"description": "Interface for creating an anoncreds proof proposal.",
+				"properties": {
+					"name": {
+						"type": "string"
+					},
+					"version": {
+						"type": "string"
+					},
+					"attributes": {
+						"items": {
+							"$ref": "#/components/schemas/AnonCredsPresentationPreviewAttribute"
+						},
+						"type": "array"
+					},
+					"predicates": {
+						"items": {
+							"$ref": "#/components/schemas/AnonCredsPresentationPreviewPredicate"
+						},
+						"type": "array"
+					},
+					"nonRevokedInterval": {
+						"$ref": "#/components/schemas/AnonCredsNonRevokedInterval"
+					}
+				},
+				"type": "object",
+				"additionalProperties": false
+			},
+			"Schema": {
+				"properties": {
+					"uri": {
+						"type": "string"
+					},
+					"required": {
+						"type": "boolean"
+					}
+				},
+				"required": [
+					"uri"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"FilterV1": {
+				"properties": {
+					"const": {
+						"$ref": "#/components/schemas/OneOfNumberStringBoolean"
+					},
+					"enum": {
+						"items": {
+							"$ref": "#/components/schemas/OneOfNumberStringBoolean"
+						},
+						"type": "array"
+					},
+					"exclusiveMinimum": {
+						"$ref": "#/components/schemas/OneOfNumberString"
+					},
+					"exclusiveMaximum": {
+						"$ref": "#/components/schemas/OneOfNumberString"
+					},
+					"format": {
+						"type": "string"
+					},
+					"minLength": {
+						"type": "number",
+						"format": "double"
+					},
+					"maxLength": {
+						"type": "number",
+						"format": "double"
+					},
+					"minimum": {
+						"$ref": "#/components/schemas/OneOfNumberString"
+					},
+					"maximum": {
+						"$ref": "#/components/schemas/OneOfNumberString"
+					},
+					"not": {
+						"additionalProperties": false,
+						"type": "object"
+					},
+					"pattern": {
+						"type": "string"
+					},
+					"type": {
+						"type": "string"
+					}
+				},
+				"type": "object",
+				"additionalProperties": false
+			},
+			"FieldV1": {
+				"properties": {
+					"id": {
+						"type": "string"
+					},
+					"path": {
+						"items": {
+							"type": "string"
+						},
+						"type": "array"
+					},
+					"purpose": {
+						"type": "string"
+					},
+					"filter": {
+						"$ref": "#/components/schemas/FilterV1"
+					},
+					"predicate": {
+						"$ref": "#/components/schemas/Optionality"
+					}
+				},
+				"required": [
+					"path"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"ConstraintsV1": {
+				"properties": {
+					"limit_disclosure": {
+						"$ref": "#/components/schemas/Optionality"
+					},
+					"statuses": {
+						"$ref": "#/components/schemas/Statuses"
+					},
+					"fields": {
+						"items": {
+							"$ref": "#/components/schemas/FieldV1"
+						},
+						"type": "array"
+					},
+					"subject_is_issuer": {
+						"$ref": "#/components/schemas/Optionality"
+					},
+					"is_holder": {
+						"items": {
+							"$ref": "#/components/schemas/HolderSubject"
+						},
+						"type": "array"
+					},
+					"same_subject": {
+						"items": {
+							"$ref": "#/components/schemas/HolderSubject"
+						},
+						"type": "array"
+					}
+				},
+				"type": "object",
+				"additionalProperties": false
+			},
+			"InputDescriptorV1": {
+				"properties": {
+					"id": {
+						"type": "string"
+					},
+					"name": {
+						"type": "string"
+					},
+					"purpose": {
+						"type": "string"
+					},
+					"group": {
+						"items": {
+							"type": "string"
+						},
+						"type": "array"
+					},
+					"schema": {
+						"items": {
+							"$ref": "#/components/schemas/Schema"
+						},
+						"type": "array"
+					},
+					"issuance": {
+						"items": {
+							"$ref": "#/components/schemas/Issuance"
+						},
+						"type": "array"
+					},
+					"constraints": {
+						"$ref": "#/components/schemas/ConstraintsV1"
+					}
+				},
+				"required": [
+					"id",
+					"schema"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"PresentationDefinitionV1": {
+				"properties": {
+					"id": {
+						"type": "string"
+					},
+					"name": {
+						"type": "string"
+					},
+					"purpose": {
+						"type": "string"
+					},
+					"format": {
+						"$ref": "#/components/schemas/Format"
+					},
+					"submission_requirements": {
+						"items": {
+							"$ref": "#/components/schemas/SubmissionRequirement"
+						},
+						"type": "array"
+					},
+					"input_descriptors": {
+						"items": {
+							"$ref": "#/components/schemas/InputDescriptorV1"
+						},
+						"type": "array"
+					}
+				},
+				"required": [
+					"id",
+					"input_descriptors"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"DidCommProofFormatPayload_ProofFormats.createProposal_": {
+				"properties": {
+					"indy": {
+						"$ref": "#/components/schemas/AnonCredsProposeProofFormat"
+					},
+					"anoncreds": {
+						"$ref": "#/components/schemas/AnonCredsProposeProofFormat"
+					},
+					"presentationExchange": {
+						"properties": {
+							"presentationDefinition": {
+								"$ref": "#/components/schemas/PresentationDefinitionV1"
+							}
+						},
+						"required": [
+							"presentationDefinition"
+						],
+						"type": "object"
+					}
+				},
+				"type": "object",
+				"description": "Get the payload for a specific method from a list of ProofFormat interfaces and a method"
 			},
 			"DidCommAutoAcceptProof": {
 				"description": "Typing of the state for auto acceptance",
@@ -4635,7 +4918,9 @@
 					"connectionId": {
 						"type": "string"
 					},
-					"proofFormats": {},
+					"proofFormats": {
+						"$ref": "#/components/schemas/DidCommProofFormatPayload_ProofFormats.createProposal_"
+					},
 					"goalCode": {
 						"type": "string"
 					},
@@ -4656,12 +4941,58 @@
 				"type": "object",
 				"additionalProperties": false
 			},
+			"DidCommProofFormatPayload_ProofFormats.acceptProposal_": {
+				"properties": {
+					"indy": {
+						"properties": {
+							"version": {
+								"type": "string"
+							},
+							"name": {
+								"type": "string"
+							}
+						},
+						"type": "object"
+					},
+					"anoncreds": {
+						"properties": {
+							"version": {
+								"type": "string"
+							},
+							"name": {
+								"type": "string"
+							}
+						},
+						"type": "object"
+					},
+					"presentationExchange": {
+						"properties": {
+							"options": {
+								"properties": {
+									"domain": {
+										"type": "string"
+									},
+									"challenge": {
+										"type": "string"
+									}
+								},
+								"type": "object"
+							}
+						},
+						"type": "object"
+					}
+				},
+				"type": "object",
+				"description": "Get the payload for a specific method from a list of ProofFormat interfaces and a method"
+			},
 			"AcceptProofProposal": {
 				"properties": {
-					"proofRecordId": {
+					"proofExchangeRecordId": {
 						"type": "string"
 					},
-					"proofFormats": {},
+					"proofFormats": {
+						"$ref": "#/components/schemas/DidCommProofFormatPayload_ProofFormats.acceptProposal_"
+					},
 					"comment": {
 						"type": "string"
 					},
@@ -4676,7 +5007,7 @@
 					}
 				},
 				"required": [
-					"proofRecordId",
+					"proofExchangeRecordId",
 					"proofFormats"
 				],
 				"type": "object",
@@ -4786,6 +5117,43 @@
 					}
 				},
 				"type": "object"
+			},
+			"OpenId4VcVerifierRecord": {
+				"$ref": "#/components/schemas/Record_string.unknown_",
+				"description": "For OID4VC you need to expos metadata files. Each issuer needs to host this metadata. This is not the case for DIDComm where we can just have one /didcomm endpoint.\nSo we create a record per openid issuer/verifier that you want, and each tenant can create multiple issuers/verifiers which have different endpoints\nand metadata files"
+			},
+			"OpenId4VcSiopVerifierClientMetadata": {
+				"properties": {
+					"client_name": {
+						"type": "string"
+					},
+					"logo_uri": {
+						"type": "string"
+					}
+				},
+				"type": "object",
+				"additionalProperties": false
+			},
+			"OpenId4VcSiopCreateVerifierOptions": {
+				"properties": {
+					"verifierId": {
+						"type": "string"
+					},
+					"clientMetadata": {
+						"$ref": "#/components/schemas/OpenId4VcSiopVerifierClientMetadata"
+					}
+				},
+				"type": "object",
+				"additionalProperties": false
+			},
+			"OpenId4VcUpdateVerifierRecordOptions": {
+				"properties": {
+					"clientMetadata": {
+						"$ref": "#/components/schemas/OpenId4VcSiopVerifierClientMetadata"
+					}
+				},
+				"type": "object",
+				"additionalProperties": false
 			}
 		},
 		"securitySchemes": {
@@ -9622,219 +9990,6 @@
 				]
 			}
 		},
-		"/openid4vc/verifier": {
-			"post": {
-				"operationId": "CreateVerifier",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/OpenId4VcVerifierRecord"
-								}
-							}
-						}
-					}
-				},
-				"description": "Create a new verifier and store the verifier record",
-				"tags": [
-					"oid4vc verifiers"
-				],
-				"security": [
-					{
-						"jwt": [
-							"tenant",
-							"dedicated"
-						]
-					}
-				],
-				"parameters": [],
-				"requestBody": {
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "#/components/schemas/OpenId4VcSiopCreateVerifierOptions"
-							}
-						}
-					}
-				}
-			},
-			"get": {
-				"operationId": "GetVerifiersByQuery",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"items": {
-										"$ref": "#/components/schemas/OpenId4VcVerifierRecord"
-									},
-									"type": "array"
-								}
-							}
-						}
-					}
-				},
-				"description": "Get verifiers by query",
-				"tags": [
-					"oid4vc verifiers"
-				],
-				"security": [
-					{
-						"jwt": [
-							"tenant",
-							"dedicated"
-						]
-					}
-				],
-				"parameters": [
-					{
-						"in": "query",
-						"name": "publicVerifierId",
-						"required": false,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			}
-		},
-		"/openid4vc/verifier/{publicVerifierId}": {
-			"put": {
-				"operationId": "UpdateVerifierMetadata",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/OpenId4VcVerifierRecord"
-								}
-							}
-						}
-					}
-				},
-				"description": "Update verifier metadata",
-				"tags": [
-					"oid4vc verifiers"
-				],
-				"security": [
-					{
-						"jwt": [
-							"tenant",
-							"dedicated"
-						]
-					}
-				],
-				"parameters": [
-					{
-						"in": "path",
-						"name": "publicVerifierId",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				],
-				"requestBody": {
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "#/components/schemas/OpenId4VcUpdateVerifierRecordOptions"
-							}
-						}
-					}
-				}
-			},
-			"get": {
-				"operationId": "GetVerifier",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/OpenId4VcVerifierRecord"
-								}
-							}
-						}
-					}
-				},
-				"description": "Get single verifier by ID",
-				"tags": [
-					"oid4vc verifiers"
-				],
-				"security": [
-					{
-						"jwt": [
-							"tenant",
-							"dedicated"
-						]
-					}
-				],
-				"parameters": [
-					{
-						"in": "path",
-						"name": "publicVerifierId",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			}
-		},
-		"/openid4vc/verifier/{verifierId}": {
-			"delete": {
-				"operationId": "DeleteVerifier",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"properties": {
-										"message": {
-											"type": "string"
-										}
-									},
-									"required": [
-										"message"
-									],
-									"type": "object"
-								}
-							}
-						}
-					}
-				},
-				"description": "Delete verifier by ID",
-				"tags": [
-					"oid4vc verifiers"
-				],
-				"security": [
-					{
-						"jwt": [
-							"tenant",
-							"dedicated"
-						]
-					}
-				],
-				"parameters": [
-					{
-						"in": "path",
-						"name": "verifierId",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
-			}
-		},
 		"/didcomm/proofs": {
 			"get": {
 				"operationId": "GetAllProofs",
@@ -10344,6 +10499,219 @@
 					{
 						"in": "path",
 						"name": "proofRecordId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
+		"/openid4vc/verifier": {
+			"post": {
+				"operationId": "CreateVerifier",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/OpenId4VcVerifierRecord"
+								}
+							}
+						}
+					}
+				},
+				"description": "Create a new verifier and store the verifier record",
+				"tags": [
+					"oid4vc verifiers"
+				],
+				"security": [
+					{
+						"jwt": [
+							"tenant",
+							"dedicated"
+						]
+					}
+				],
+				"parameters": [],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/OpenId4VcSiopCreateVerifierOptions"
+							}
+						}
+					}
+				}
+			},
+			"get": {
+				"operationId": "GetVerifiersByQuery",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"items": {
+										"$ref": "#/components/schemas/OpenId4VcVerifierRecord"
+									},
+									"type": "array"
+								}
+							}
+						}
+					}
+				},
+				"description": "Get verifiers by query",
+				"tags": [
+					"oid4vc verifiers"
+				],
+				"security": [
+					{
+						"jwt": [
+							"tenant",
+							"dedicated"
+						]
+					}
+				],
+				"parameters": [
+					{
+						"in": "query",
+						"name": "publicVerifierId",
+						"required": false,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
+		"/openid4vc/verifier/{publicVerifierId}": {
+			"put": {
+				"operationId": "UpdateVerifierMetadata",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/OpenId4VcVerifierRecord"
+								}
+							}
+						}
+					}
+				},
+				"description": "Update verifier metadata",
+				"tags": [
+					"oid4vc verifiers"
+				],
+				"security": [
+					{
+						"jwt": [
+							"tenant",
+							"dedicated"
+						]
+					}
+				],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "publicVerifierId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/OpenId4VcUpdateVerifierRecordOptions"
+							}
+						}
+					}
+				}
+			},
+			"get": {
+				"operationId": "GetVerifier",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/OpenId4VcVerifierRecord"
+								}
+							}
+						}
+					}
+				},
+				"description": "Get single verifier by ID",
+				"tags": [
+					"oid4vc verifiers"
+				],
+				"security": [
+					{
+						"jwt": [
+							"tenant",
+							"dedicated"
+						]
+					}
+				],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "publicVerifierId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
+		"/openid4vc/verifier/{verifierId}": {
+			"delete": {
+				"operationId": "DeleteVerifier",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"properties": {
+										"message": {
+											"type": "string"
+										}
+									},
+									"required": [
+										"message"
+									],
+									"type": "object"
+								}
+							}
+						}
+					}
+				},
+				"description": "Delete verifier by ID",
+				"tags": [
+					"oid4vc verifiers"
+				],
+				"security": [
+					{
+						"jwt": [
+							"tenant",
+							"dedicated"
+						]
+					}
+				],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "verifierId",
 						"required": true,
 						"schema": {
 							"type": "string"

--- a/src/routes/swagger.json
+++ b/src/routes/swagger.json
@@ -4915,6 +4915,9 @@
 			},
 			"RequestProofProposalOptions": {
 				"properties": {
+					"protocolVersion": {
+						"$ref": "#/components/schemas/ProtocolVersion"
+					},
 					"connectionId": {
 						"type": "string"
 					},
@@ -4935,6 +4938,7 @@
 					}
 				},
 				"required": [
+					"protocolVersion",
 					"connectionId",
 					"proofFormats"
 				],
@@ -10149,7 +10153,7 @@
 				}
 			}
 		},
-		"/didcomm/proofs/{proofRecordId}/accept-proposal": {
+		"/didcomm/proofs/accept-proposal": {
 			"post": {
 				"operationId": "AcceptProposal",
 				"responses": {

--- a/src/routes/swagger.json
+++ b/src/routes/swagger.json
@@ -4617,6 +4617,175 @@
 				},
 				"type": "object",
 				"additionalProperties": false
+			},
+			"DidCommProofExchangeRecord": {
+				"$ref": "#/components/schemas/Record_string.unknown_"
+			},
+			"DidCommAutoAcceptProof": {
+				"description": "Typing of the state for auto acceptance",
+				"enum": [
+					"always",
+					"contentApproved",
+					"never"
+				],
+				"type": "string"
+			},
+			"RequestProofProposalOptions": {
+				"properties": {
+					"connectionId": {
+						"type": "string"
+					},
+					"proofFormats": {},
+					"goalCode": {
+						"type": "string"
+					},
+					"parentThreadId": {
+						"type": "string"
+					},
+					"autoAcceptProof": {
+						"$ref": "#/components/schemas/DidCommAutoAcceptProof"
+					},
+					"comment": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"connectionId",
+					"proofFormats"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"AcceptProofProposal": {
+				"properties": {
+					"proofRecordId": {
+						"type": "string"
+					},
+					"proofFormats": {},
+					"comment": {
+						"type": "string"
+					},
+					"autoAcceptProof": {
+						"$ref": "#/components/schemas/DidCommAutoAcceptProof"
+					},
+					"goalCode": {
+						"type": "string"
+					},
+					"willConfirm": {
+						"type": "boolean"
+					}
+				},
+				"required": [
+					"proofRecordId",
+					"proofFormats"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"RequestProofOptions": {
+				"properties": {
+					"connectionId": {
+						"type": "string"
+					},
+					"protocolVersion": {
+						"type": "string"
+					},
+					"proofFormats": {},
+					"comment": {
+						"type": "string"
+					},
+					"autoAcceptProof": {
+						"$ref": "#/components/schemas/DidCommAutoAcceptProof"
+					},
+					"goalCode": {
+						"type": "string"
+					},
+					"parentThreadId": {
+						"type": "string"
+					},
+					"willConfirm": {
+						"type": "boolean"
+					}
+				},
+				"required": [
+					"connectionId",
+					"protocolVersion",
+					"proofFormats",
+					"comment",
+					"autoAcceptProof"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"CreateProofRequestOobOptions": {
+				"properties": {
+					"protocolVersion": {
+						"type": "string"
+					},
+					"proofFormats": {},
+					"goalCode": {
+						"type": "string"
+					},
+					"parentThreadId": {
+						"type": "string"
+					},
+					"willConfirm": {
+						"type": "boolean"
+					},
+					"autoAcceptProof": {
+						"$ref": "#/components/schemas/DidCommAutoAcceptProof"
+					},
+					"comment": {
+						"type": "string"
+					},
+					"label": {
+						"type": "string"
+					},
+					"imageUrl": {
+						"type": "string"
+					},
+					"recipientKey": {
+						"type": "string"
+					},
+					"invitationDid": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"protocolVersion",
+					"proofFormats"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"ProofFormatDataMessagePayload__40_LegacyIndyDidCommProofFormat-or-AnonCredsDidCommProofFormat-or-DidCommDifPresentationExchangeProofFormat_41_-Array.proposal_": {
+				"properties": {},
+				"type": "object",
+				"description": "Get the format data payload for a specific message from a list of ProofFormat interfaces and a message\n\nFor an indy offer, this resolves to the proof request format as defined here:\nhttps://github.com/hyperledger/aries-rfcs/tree/b3a3942ef052039e73cd23d847f42947f8287da2/features/0592-indy-attachments#proof-request-format"
+			},
+			"ProofFormatDataMessagePayload__40_LegacyIndyDidCommProofFormat-or-AnonCredsDidCommProofFormat-or-DidCommDifPresentationExchangeProofFormat_41_-Array.request_": {
+				"properties": {},
+				"type": "object",
+				"description": "Get the format data payload for a specific message from a list of ProofFormat interfaces and a message\n\nFor an indy offer, this resolves to the proof request format as defined here:\nhttps://github.com/hyperledger/aries-rfcs/tree/b3a3942ef052039e73cd23d847f42947f8287da2/features/0592-indy-attachments#proof-request-format"
+			},
+			"ProofFormatDataMessagePayload__40_LegacyIndyDidCommProofFormat-or-AnonCredsDidCommProofFormat-or-DidCommDifPresentationExchangeProofFormat_41_-Array.presentation_": {
+				"properties": {},
+				"type": "object",
+				"description": "Get the format data payload for a specific message from a list of ProofFormat interfaces and a message\n\nFor an indy offer, this resolves to the proof request format as defined here:\nhttps://github.com/hyperledger/aries-rfcs/tree/b3a3942ef052039e73cd23d847f42947f8287da2/features/0592-indy-attachments#proof-request-format"
+			},
+			"GetProofFormatDataReturn__40_LegacyIndyDidCommProofFormat-or-AnonCredsDidCommProofFormat-or-DidCommDifPresentationExchangeProofFormat_41_-Array_": {
+				"properties": {
+					"presentation": {
+						"$ref": "#/components/schemas/ProofFormatDataMessagePayload__40_LegacyIndyDidCommProofFormat-or-AnonCredsDidCommProofFormat-or-DidCommDifPresentationExchangeProofFormat_41_-Array.presentation_"
+					},
+					"request": {
+						"$ref": "#/components/schemas/ProofFormatDataMessagePayload__40_LegacyIndyDidCommProofFormat-or-AnonCredsDidCommProofFormat-or-DidCommDifPresentationExchangeProofFormat_41_-Array.request_"
+					},
+					"proposal": {
+						"$ref": "#/components/schemas/ProofFormatDataMessagePayload__40_LegacyIndyDidCommProofFormat-or-AnonCredsDidCommProofFormat-or-DidCommDifPresentationExchangeProofFormat_41_-Array.proposal_"
+					}
+				},
+				"type": "object"
 			}
 		},
 		"securitySchemes": {
@@ -9658,6 +9827,523 @@
 					{
 						"in": "path",
 						"name": "verifierId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
+		"/didcomm/proofs": {
+			"get": {
+				"operationId": "GetAllProofs",
+				"responses": {
+					"200": {
+						"description": "ProofRecord[]",
+						"content": {
+							"application/json": {
+								"schema": {
+									"items": {
+										"$ref": "#/components/schemas/Record_string.unknown_"
+									},
+									"type": "array"
+								},
+								"examples": {
+									"Example 1": {
+										"value": [
+											{
+												"metadata": {},
+												"id": "821f9b26-ad04-4f56-89b6-e2ef9c72b36e",
+												"createdAt": "2022-01-01T00:00:00.000Z",
+												"connectionId": "2aecf74c-3073-4f98-9acb-92415d096834",
+												"threadId": "0019d466-5eea-4269-8c40-031b4896c5b7",
+												"protocolVersion": "v1"
+											}
+										]
+									}
+								}
+							}
+						}
+					}
+				},
+				"description": "Retrieve all proof records",
+				"tags": [
+					"DIDComm - Proofs"
+				],
+				"security": [
+					{
+						"jwt": [
+							"tenant",
+							"dedicated"
+						]
+					}
+				],
+				"parameters": [
+					{
+						"in": "query",
+						"name": "threadId",
+						"required": false,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
+		"/didcomm/proofs/{proofRecordId}": {
+			"get": {
+				"operationId": "GetProofById",
+				"responses": {
+					"200": {
+						"description": "ProofRecord",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Record_string.unknown_"
+								},
+								"examples": {
+									"Example 1": {
+										"value": {
+											"metadata": {},
+											"id": "821f9b26-ad04-4f56-89b6-e2ef9c72b36e",
+											"createdAt": "2022-01-01T00:00:00.000Z",
+											"connectionId": "2aecf74c-3073-4f98-9acb-92415d096834",
+											"threadId": "0019d466-5eea-4269-8c40-031b4896c5b7",
+											"protocolVersion": "v1"
+										}
+									}
+								}
+							}
+						}
+					}
+				},
+				"description": "Retrieve proof record by proof record id",
+				"tags": [
+					"DIDComm - Proofs"
+				],
+				"security": [
+					{
+						"jwt": [
+							"tenant",
+							"dedicated"
+						]
+					}
+				],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "proofRecordId",
+						"required": true,
+						"schema": {
+							"$ref": "#/components/schemas/RecordId"
+						}
+					}
+				]
+			}
+		},
+		"/didcomm/proofs/propose-proof": {
+			"post": {
+				"operationId": "ProposeProof",
+				"responses": {
+					"200": {
+						"description": "ProofRecord",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/DidCommProofExchangeRecord"
+								},
+								"examples": {
+									"Example 1": {
+										"value": {
+											"metadata": {},
+											"id": "821f9b26-ad04-4f56-89b6-e2ef9c72b36e",
+											"createdAt": "2022-01-01T00:00:00.000Z",
+											"connectionId": "2aecf74c-3073-4f98-9acb-92415d096834",
+											"threadId": "0019d466-5eea-4269-8c40-031b4896c5b7",
+											"protocolVersion": "v1"
+										}
+									}
+								}
+							}
+						}
+					}
+				},
+				"description": "Initiate a new presentation exchange as prover by sending a presentation proposal request\nto the connection with the specified connection id.",
+				"tags": [
+					"DIDComm - Proofs"
+				],
+				"security": [
+					{
+						"jwt": [
+							"tenant",
+							"dedicated"
+						]
+					}
+				],
+				"parameters": [],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/RequestProofProposalOptions"
+							}
+						}
+					}
+				}
+			}
+		},
+		"/didcomm/proofs/{proofRecordId}/accept-proposal": {
+			"post": {
+				"operationId": "AcceptProposal",
+				"responses": {
+					"200": {
+						"description": "ProofRecord",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/DidCommProofExchangeRecord"
+								},
+								"examples": {
+									"Example 1": {
+										"value": {
+											"metadata": {},
+											"id": "821f9b26-ad04-4f56-89b6-e2ef9c72b36e",
+											"createdAt": "2022-01-01T00:00:00.000Z",
+											"connectionId": "2aecf74c-3073-4f98-9acb-92415d096834",
+											"threadId": "0019d466-5eea-4269-8c40-031b4896c5b7",
+											"protocolVersion": "v1"
+										}
+									}
+								}
+							}
+						}
+					}
+				},
+				"description": "Accept a presentation proposal as verifier by sending an accept proposal message\nto the connection associated with the proof record.",
+				"tags": [
+					"DIDComm - Proofs"
+				],
+				"security": [
+					{
+						"jwt": [
+							"tenant",
+							"dedicated"
+						]
+					}
+				],
+				"parameters": [],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/AcceptProofProposal"
+							}
+						}
+					}
+				}
+			}
+		},
+		"/didcomm/proofs/request-proof": {
+			"post": {
+				"operationId": "RequestProof",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/DidCommProofExchangeRecord"
+								},
+								"examples": {
+									"Example 1": {
+										"value": {
+											"metadata": {},
+											"id": "821f9b26-ad04-4f56-89b6-e2ef9c72b36e",
+											"createdAt": "2022-01-01T00:00:00.000Z",
+											"connectionId": "2aecf74c-3073-4f98-9acb-92415d096834",
+											"threadId": "0019d466-5eea-4269-8c40-031b4896c5b7",
+											"protocolVersion": "v1"
+										}
+									}
+								}
+							}
+						}
+					}
+				},
+				"description": "Creates a presentation request bound to existing connection",
+				"tags": [
+					"DIDComm - Proofs"
+				],
+				"security": [
+					{
+						"jwt": [
+							"tenant",
+							"dedicated"
+						]
+					}
+				],
+				"parameters": [],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/RequestProofOptions"
+							}
+						}
+					}
+				}
+			}
+		},
+		"/didcomm/proofs/create-request-oob": {
+			"post": {
+				"operationId": "CreateRequest",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"properties": {
+										"proofMessageId": {
+											"type": "string"
+										},
+										"proofRecordThId": {
+											"type": "string"
+										},
+										"invitationDid": {
+											"type": "string"
+										},
+										"outOfBandRecord": {
+											"$ref": "#/components/schemas/Record_string.unknown_"
+										},
+										"invitation": {
+											"$ref": "#/components/schemas/DidCommPlaintextMessage"
+										},
+										"invitationUrl": {
+											"type": "string"
+										}
+									},
+									"required": [
+										"proofMessageId",
+										"proofRecordThId",
+										"invitationDid",
+										"outOfBandRecord",
+										"invitation",
+										"invitationUrl"
+									],
+									"type": "object"
+								},
+								"examples": {
+									"Example 1": {
+										"value": {
+											"metadata": {},
+											"id": "821f9b26-ad04-4f56-89b6-e2ef9c72b36e",
+											"createdAt": "2022-01-01T00:00:00.000Z",
+											"connectionId": "2aecf74c-3073-4f98-9acb-92415d096834",
+											"threadId": "0019d466-5eea-4269-8c40-031b4896c5b7",
+											"protocolVersion": "v1"
+										}
+									}
+								}
+							}
+						}
+					}
+				},
+				"description": "Creates a presentation request not bound to any proposal or existing connection",
+				"tags": [
+					"DIDComm - Proofs"
+				],
+				"security": [
+					{
+						"jwt": [
+							"tenant",
+							"dedicated"
+						]
+					}
+				],
+				"parameters": [],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/CreateProofRequestOobOptions"
+							}
+						}
+					}
+				}
+			}
+		},
+		"/didcomm/proofs/{proofRecordId}/accept-request": {
+			"post": {
+				"operationId": "AcceptRequest",
+				"responses": {
+					"200": {
+						"description": "ProofRecord",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Record_string.unknown_"
+								},
+								"examples": {
+									"Example 1": {
+										"value": {
+											"metadata": {},
+											"id": "821f9b26-ad04-4f56-89b6-e2ef9c72b36e",
+											"createdAt": "2022-01-01T00:00:00.000Z",
+											"connectionId": "2aecf74c-3073-4f98-9acb-92415d096834",
+											"threadId": "0019d466-5eea-4269-8c40-031b4896c5b7",
+											"protocolVersion": "v1"
+										}
+									}
+								}
+							}
+						}
+					}
+				},
+				"description": "Accept a presentation request as prover by sending an accept request message\nto the connection associated with the proof record.",
+				"tags": [
+					"DIDComm - Proofs"
+				],
+				"security": [
+					{
+						"jwt": [
+							"tenant",
+							"dedicated"
+						]
+					}
+				],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "proofRecordId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"properties": {
+									"comment": {
+										"type": "string"
+									},
+									"filterByNonRevocationRequirements": {
+										"type": "boolean"
+									},
+									"filterByPresentationPreview": {
+										"type": "boolean"
+									}
+								},
+								"type": "object"
+							}
+						}
+					}
+				}
+			}
+		},
+		"/didcomm/proofs/{proofRecordId}/accept-presentation": {
+			"post": {
+				"operationId": "AcceptPresentation",
+				"responses": {
+					"200": {
+						"description": "ProofRecord",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/DidCommProofExchangeRecord"
+								},
+								"examples": {
+									"Example 1": {
+										"value": {
+											"metadata": {},
+											"id": "821f9b26-ad04-4f56-89b6-e2ef9c72b36e",
+											"createdAt": "2022-01-01T00:00:00.000Z",
+											"connectionId": "2aecf74c-3073-4f98-9acb-92415d096834",
+											"threadId": "0019d466-5eea-4269-8c40-031b4896c5b7",
+											"protocolVersion": "v1"
+										}
+									}
+								}
+							}
+						}
+					}
+				},
+				"description": "Accept a presentation as prover by sending an accept presentation message\nto the connection associated with the proof record.",
+				"tags": [
+					"DIDComm - Proofs"
+				],
+				"security": [
+					{
+						"jwt": [
+							"tenant",
+							"dedicated"
+						]
+					}
+				],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "proofRecordId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
+		"/didcomm/proofs/{proofRecordId}/form-data": {
+			"get": {
+				"operationId": "ProofFormData",
+				"responses": {
+					"200": {
+						"description": "ProofRecord",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/GetProofFormatDataReturn__40_LegacyIndyDidCommProofFormat-or-AnonCredsDidCommProofFormat-or-DidCommDifPresentationExchangeProofFormat_41_-Array_"
+								},
+								"examples": {
+									"Example 1": {
+										"value": {
+											"metadata": {},
+											"id": "821f9b26-ad04-4f56-89b6-e2ef9c72b36e",
+											"createdAt": "2022-01-01T00:00:00.000Z",
+											"connectionId": "2aecf74c-3073-4f98-9acb-92415d096834",
+											"threadId": "0019d466-5eea-4269-8c40-031b4896c5b7",
+											"protocolVersion": "v1"
+										}
+									}
+								}
+							}
+						}
+					}
+				},
+				"description": "Return proofRecord",
+				"tags": [
+					"DIDComm - Proofs"
+				],
+				"security": [
+					{
+						"jwt": [
+							"tenant",
+							"dedicated"
+						]
+					}
+				],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "proofRecordId",
 						"required": true,
 						"schema": {
 							"type": "string"


### PR DESCRIPTION
## What
- fix proof controller types

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Activated authenticated DIDComm proof REST endpoints: list/get proofs, propose/request proofs, accept proposals/requests, accept presentations, and retrieve proof format form data.
  * Out-of-band proof request creation now returns DIDComm-style invitations.

* **Enhancements**
  * Proof APIs now use explicit DIDComm proof format typing and improved payload schemas.

* **Documentation**
  * OpenAPI docs updated with full DIDComm proof models and endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Breaking
- for body of endpoint `'/:proofRecordId/accept-proposal'`, the key `proofRecordId` has been updated to `proofExchangeRecordId`
- The endpoint `/:proofRecordId/accept-proposal` is changed to `/accept-proposal` 
Note: This is because `proofRecordId` is not being used in the API. An equivalent key is instead accepted in body.