### PR TITLE
feat: configurable webhook timeout

### DIFF
--- a/.env.demo
+++ b/.env.demo
@@ -68,6 +68,8 @@ OID4VP_AUTH_REQUEST_PROOF_REQUEST_EXPIRY=3600
 APP_JSON_BODY_SIZE=5mb
 APP_URL_ENCODED_BODY_SIZE=5mb
 
+# Webhook awaited expiry is in milliseconds
+WEBHOOK_TIMEOUT_MS=10000
 
 API_KEY=supersecret-that-too-16chars
 UPDATE_JWT_SECRET=false

--- a/src/events/WebhookEvent.ts
+++ b/src/events/WebhookEvent.ts
@@ -8,14 +8,18 @@ export const sendWebhookEvent = async (
   webhookUrl: string,
   body: Record<string, unknown>,
   logger: Logger,
-  timeoutMs: number = parseInt(process.env.WEBHOOK_TIMEOUT_MS || '', 10) || DEFAULT_TIMEOUT,
+  timeoutMs?: number,
 ): Promise<void> => {
 
-  console.log(`Sending webhook event to ${webhookUrl} with timeout of ${timeoutMs}ms`)
+  const envTimeout = parseInt(process.env.WEBHOOK_TIMEOUT_MS ?? '', 10)
+  const candidateTimeout = timeoutMs ?? envTimeout
+  const resolvedTimeout = candidateTimeout > 0 ? candidateTimeout : DEFAULT_TIMEOUT
+
+  logger.info(`Sending webhook event to ${webhookUrl} with timeout of ${resolvedTimeout}ms`)
   // Abort the webhook send events if the request hangs-in for >5 secs
   // This can avoid failure of services due to bad webhook listners
   const controller = new AbortController()
-  const timeout = setTimeout(() => controller.abort(), timeoutMs)
+  const timeout = setTimeout(() => controller.abort(), resolvedTimeout)
 
   try {
     await fetch(webhookUrl, {

--- a/src/events/WebhookEvent.ts
+++ b/src/events/WebhookEvent.ts
@@ -2,12 +2,16 @@ import type { Logger } from '@credo-ts/core'
 
 import fetch from 'node-fetch'
 
+const DEFAULT_TIMEOUT = 5000;
+
 export const sendWebhookEvent = async (
   webhookUrl: string,
   body: Record<string, unknown>,
   logger: Logger,
-  timeoutMs = 5000,
+  timeoutMs: number = parseInt(process.env.WEBHOOK_TIMEOUT_MS || '', 10) || DEFAULT_TIMEOUT,
 ): Promise<void> => {
+
+  console.log(`Sending webhook event to ${webhookUrl} with timeout of ${timeoutMs}ms`)
   // Abort the webhook send events if the request hangs-in for >5 secs
   // This can avoid failure of services due to bad webhook listners
   const controller = new AbortController()


### PR DESCRIPTION
## What
- Make webhook timeout configurable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Webhook timeouts are now configurable through an environment variable with a 5-second default fallback.
  * Added logging to display the webhook URL and timeout value during message transmission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->